### PR TITLE
Replace VS Code marketplace publishing with GitHub release uploads

### DIFF
--- a/.github/workflows/publish.vscode.yml
+++ b/.github/workflows/publish.vscode.yml
@@ -1,7 +1,28 @@
+# Keeper Security VS Code Extension - Release Workflow
+#
+# HOW TO PUBLISH A NEW RELEASE:
+# 1. Update the version in package.json (e.g., from 1.0.0 to 1.0.1)
+# 2. Commit your changes: git commit -am "Bump version to 1.0.1"
+# 3. Create a git tag matching the version: git tag v1.0.1
+# 4. Push the tag to GitHub: git push origin v1.0.1
+# 5. The workflow will automatically:
+#    - Run tests and linting
+#    - Build the extension
+#    - Generate SBOM
+#    - Create a GitHub release with the VSIX file attached
+#
+# The VSIX file can be manually installed in VS Code via:
+# Extensions view > ... menu > Install from VSIX...
+#
+# Note: This workflow triggers on version tags (v*.*.*) or manual workflow dispatch
+
 name: Publish VS Code Extension
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'  # Triggers on version tags like v1.0.0, v1.0.1, etc.
     
 jobs:
   test:
@@ -121,10 +142,43 @@ jobs:
           echo "---------- SBOM Preview (first 20 lines) ----------"
           head -n 20 vscode-extension-sbom.json
 
-  publish:
+  # Marketplace publish job - reserved for future use
+  # publish:
+  #   runs-on: ubuntu-latest
+  #   environment: prod 
+  #   needs: [test, build, generate-sbom]
+  #
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Use Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '20.x'
+  #         cache: 'npm'
+  #
+  #     - name: Install dependencies
+  #       run: npm ci
+  #
+  #     - name: Download build artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: extension-build
+  #         path: ./
+  #
+  #     - name: Publish to VS Code Marketplace
+  #       run: |
+  #         echo "Publishing version $(node -p "require('./package.json').version")..."
+  #         npm run publish
+  #       env:
+  #         VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  create-release:
     runs-on: ubuntu-latest
-    environment: prod 
     needs: [test, build, generate-sbom]
+    # Only run when triggered by a tag push
+    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout code
@@ -139,15 +193,64 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: extension-build
-          path: ./
-
-      - name: Publish to VS Code Marketplace
+      - name: Get version
+        id: get_version
         run: |
-          echo "Publishing version $(node -p "require('./package.json').version")..."
-          npm run publish
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+
+      - name: Package extension with version
+        run: |
+          # Get version from package.json
+          VERSION=${{ steps.get_version.outputs.version }}
+          echo "Building version: ${VERSION}"
+          
+          # Create VSIX package with version in filename
+          npx vsce package --out "keeper-vscode-extension-${VERSION}.vsix"
+          
+          # List the created file
+          echo "Created package:"
+          ls -la *.vsix
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            ## Keeper Security VS Code Extension ${{ github.ref_name }}
+            
+            ### Installation
+            
+            #### Manual Installation (VSIX):
+            1. Download the `keeper-vscode-extension-${{ steps.get_version.outputs.version }}.vsix` file from the assets below
+            2. Open VS Code
+            3. Open Command Palette (Ctrl+Shift+P or Cmd+Shift+P)
+            4. Type "Install from VSIX" and select "Extensions: Install from VSIX..."
+            5. Choose the downloaded VSIX file
+            
+            #### Alternative Method:
+            1. Download the VSIX file
+            2. Open Extensions view (Ctrl+Shift+X or Cmd+Shift+X)
+            3. Click the "..." menu at the top of the Extensions view
+            4. Select "Install from VSIX..."
+            5. Select the downloaded file
+            
+            ### What's Changed
+            See the [full changelog](https://github.com/Keeper-Security/keeper-vscode-extension/compare/previous-tag...${{ github.ref_name }})
+          draft: false
+          prerelease: false
+
+      - name: Upload VSIX to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./keeper-vscode-extension-${{ steps.get_version.outputs.version }}.vsix
+          asset_name: keeper-vscode-extension-${{ steps.get_version.outputs.version }}.vsix
+          asset_content_type: application/vsix

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ yarn-error.log*
 
 # Temporary files
 *.tmp
-*.temp
+*.temp.idea/


### PR DESCRIPTION
## Summary
This PR modifies the GitHub Actions workflow to publish releases directly to GitHub instead of the VS Code marketplace, making it easier to distribute the extension without marketplace credentials.

## Changes Made
- 🔄 **Replaced marketplace publishing** with GitHub release creation
- 📦 **VSIX package creation** with versioned filename: `keeper-security-vscode-{version}.vsix`

## How to Publish a Release
1. Update version in `package.json`
2. Commit changes: `git commit -am "Bump version to x.x.x"`
3. Create tag: `git tag vx.x.x`
4. Push tag: `git push origin vx.x.x`
5. GitHub Actions automatically creates a release with VSIX attached

## Installation Instructions
Users can install the extension from GitHub releases:
1. Download the `.vsix` file from the release
2. Open VS Code Command Palette (Cmd/Ctrl+Shift+P)
3. Run "Extensions: Install from VSIX..."
4. Select the downloaded file