### PR TITLE
Fix VS Code Marketplace publisher ID mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Never commit secrets to your code again - secure them in Keeper vault",
   "version": "1.0.0",
   "license": "MIT",
-  "publisher": "keeper-security",
+  "publisher": "KeeperSecurityDev",
   "galleryBanner": {
     "color": "#1a365d",
     "theme": "dark"


### PR DESCRIPTION
## Summary
- Fixed publisher ID mismatch that was preventing VS Code extension publication
- Updated publisher ID from `keeper-security` to `KeeperSecurityDev` to match the marketplace account

## Problem
The extension manifest contained publisher ID `keeper-security` but the marketplace publishing was attempted under the `KeeperSecurityDev` account, causing an upload error.

## Solution
Updated the publisher field in `package.json` to match the correct publisher account.