### PR TITLE
Fix GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/publish.vscode.yml
+++ b/.github/workflows/publish.vscode.yml
@@ -214,13 +214,10 @@ jobs:
           ls -la *.vsix
 
       - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: |
             ## Keeper Security VS Code Extension ${{ github.ref_name }}
             
@@ -244,13 +241,6 @@ jobs:
             See the [full changelog](https://github.com/Keeper-Security/keeper-vscode-extension/compare/previous-tag...${{ github.ref_name }})
           draft: false
           prerelease: false
-
-      - name: Upload VSIX to Release
-        uses: actions/upload-release-asset@v1
+          files: ./keeper-vscode-extension-${{ steps.get_version.outputs.version }}.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./keeper-vscode-extension-${{ steps.get_version.outputs.version }}.vsix
-          asset_name: keeper-vscode-extension-${{ steps.get_version.outputs.version }}.vsix
-          asset_content_type: application/vsix


### PR DESCRIPTION
This PR fixes deprecation warnings in the GitHub Actions workflow for publishing the VS Code extension.

