### PR TITLE
Implement keeperdrive changes into cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,5 @@ yarn-error.log*
 .env.*.local
 
 # Temporary files
-*.tmp
+*.tmp/
 *.temp.idea/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -33,3 +33,12 @@ test/**
 
 # Source maps
 **/*.map
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Temporary files
+*.tmp/
+*.temp.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 2.1.0
+
+- **Nested Share Folder Support** (CLI mode): Added support for Keeper's new nested share folders alongside classic folders.
+  - Folder picker now distinguishes between `(Nested Share Folder)` and `(Classic Folder)` folders.
+- **Permission Model Selection in My Vault** (CLI mode): When the current storage is `My Vault` (root), `Generate Password` and `Save Value to Vault` now prompt the user to choose between:
+  - `Use classic permission model` — creates the record with classic permission model.
+  - `Use new permission model` — creates the record with new permission model.
+- **Combined Record Listing for My Vault** (CLI mode): `Get Value from Vault` now fetches both classic records and nested share folder records and shows them together in a single quick pick when the current storage is `My Vault`.
+- **Security fixes**:
+  - Reject Keeper references containing line breaks or other control characters in `.env` files used by the `Run Securely` command.
+  - Validate Keeper record UIDs and arguments passed to Keeper Commander, rejecting values that contain control characters or unsafe characters.
+  - Hardened `createKeeperReference` and `validateKeeperReference` to reject record UIDs that are not URL-safe base64 tokens.
+- **Performance**:
+  - Faster authentication check: replaced the `this-device` probe with `login-status`, which is significantly quicker for vaults with large amounts of data. Auth-check timeout extended to 5 minutes for slow networks/setups.
+  - `sync-down` is now invoked with `--force` so that the latest records are always fetched when retrieving folders or records.
+- **Dependencies**:
+  - Bumped `webpack` to `^5.105.2`.
+  - Added overrides for `diff` and `serialize-javascript` to address transitive vulnerabilities.
+
 ## 2.0.1
 
 - **Security**: Updated dependencies to address known vulnerabilities:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 ## 2.1.0
 
-- **Nested Share Folder Support** (CLI mode): Added support for Keeper's new nested share folders alongside classic folders.
+- **Nested Share Folder Support** (In CLI mode): Added support for Keeper's new nested share folders alongside classic folders.
   - Folder picker now distinguishes between `(Nested Share Folder)` and `(Classic Folder)` folders.
-- **Permission Model Selection in My Vault** (CLI mode): When the current storage is `My Vault` (root), `Generate Password` and `Save Value to Vault` now prompt the user to choose between:
+- **Permission Model Selection in My Vault** (In CLI mode): When the current storage is `My Vault` (root), `Generate Password` and `Save Value to Vault` now prompt the user to choose between:
   - `Use classic permission model` — creates the record with classic permission model.
   - `Use new permission model` — creates the record with new permission model.
-- **Combined Record Listing for My Vault** (CLI mode): `Get Value from Vault` now fetches both classic records and nested share folder records and shows them together in a single quick pick when the current storage is `My Vault`.
 - **Security fixes**:
   - Reject Keeper references containing line breaks or other control characters in `.env` files used by the `Run Securely` command.
   - Validate Keeper record UIDs and arguments passed to Keeper Commander, rejecting values that contain control characters or unsafe characters.
   - Hardened `createKeeperReference` and `validateKeeperReference` to reject record UIDs that are not URL-safe base64 tokens.
+  - The legacy Keeper Commander executor now spawns the CLI directly via `execFile` with a tokenized argv instead of `exec` with a concatenated command string. No shell is involved, so shell metacharacters in arguments cannot be interpreted as syntax even if they bypass upstream validation. The persistent-process path already used this model; the legacy path now matches it.
+  - Declared `capabilities.untrustedWorkspaces.supported = false` so the extension is disabled by default in VS Code Restricted Mode. The Run Securely command parses workspace `.env` files and invokes a local CLI; running in untrusted workspaces is not safe.
 - **Performance**:
   - Faster authentication check: replaced the `this-device` probe with `login-status`, which is significantly quicker for vaults with large amounts of data. Auth-check timeout extended to 5 minutes for slow networks/setups.
   - `sync-down` is now invoked with `--force` so that the latest records are always fetched when retrieving folders or records.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This enable developers to manage secrets securely without leaving their developm
 ### For CLI Mode:
 
 - **Keeper Commander CLI**:
-  - The **Keeper Commander CLI** must be installed globally on your system using the official binary.
+  - The **Keeper Commander CLI v18.0.5 or later** must be installed globally on your system using the official binary.
   - Authenticated using [Persistent login](https://docs.keeper.io/en/keeperpam/commander-cli/commander-installation-setup/logging-in#persistent-login-sessions-stay-logged-in) or [Biometric login](https://docs.keeper.io/en/keeperpam/commander-cli/commander-installation-setup/logging-in#logging-in-with-biometric-authentication)
 
 ### For KSM Mode:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,25 +31,11 @@
         "ts-jest": "^29.1.2",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
-        "webpack": "^5.99.7",
+        "webpack": "^5.105.2",
         "webpack-cli": "^6.0.1"
       },
       "engines": {
         "vscode": "^1.99.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -83,14 +69,14 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.0.tgz",
-      "integrity": "sha512-88Djs5vBvGbHQHf5ZZcaoNHo6Y8BKZkt3cw2iuJIQzLEgH4Ox6Tm4hjFhbqOxyYsgIG/eJbFEHpxRIfEEWv5Ow==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.11.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -98,18 +84,18 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.0.tgz",
-      "integrity": "sha512-O4aP3CLFNodg8eTHXECaH3B3CjicfzkxVtnrfLkOq0XNP7TIECGfHpK/C6vADZkWP75wzmdBnsIA8ksuJMk18g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.20.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -117,18 +103,18 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
-      "integrity": "sha512-OKHmb3/Kpm06HypvB3g6Q3zJuvyXcpxDpCS1PnU8OV6AJgSFaee/covXBcPbWc6XDDxtEPlbi3EMQ6nUiPaQtw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.8.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -136,9 +122,9 @@
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
-      "integrity": "sha512-+XvmZLLWPe67WXNZo9Oc9CrPj/Tm8QnHR92fFAFdnbzwNdCH1h+7UdpaQgRSBsMY+oW1kHXNUZQLdZ1gHX3ROw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -149,13 +135,13 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.0.tgz",
-      "integrity": "sha512-o0psW8QWQ58fq3i24Q1K2XfS/jYTxr7O1HRcyUE9bV9NttLU+kYOH82Ixj8DGlMTOWgxm1Sss2QAfKK5UkSPxw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
+        "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
@@ -164,9 +150,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.11.1.tgz",
-      "integrity": "sha512-0ZdsLRaOyLxtCYgyuqyWqGU5XQ9gGnjxgfoNTt1pvELGkkUFrMATABZFIq8gusM7N1qbqpVtwLOhk0d/3kacLg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -177,8 +163,8 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
@@ -201,22 +187,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.21.1.tgz",
-      "integrity": "sha512-qGtzX3HJfJsOVeDcVrFZAYZoxLRjrW2lXzXqijgiBA5EtM9ud7F/EYgKKQ9TJU/WtE46szuZtQZx5vD4pEiknA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.1.tgz",
+      "integrity": "sha512-hTbvOi9Ko2Jvn+G/fSmjzHf9WbNcf/o3epMtbeGx/pMwMrVAbi6OgCJVeCfsAb8IybSRpaCSc4EDRlYAhgngUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.12.0"
+        "@azure/msal-common": "16.6.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
-      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.1.tgz",
+      "integrity": "sha512-VxKdEtUwDuLD0F1hOQP7kye0YadZxFJfv37Em440geEf/w9uggKnHpRrqwZJOdxmPUOdhZ9kyRtKuAJW8wUcRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -224,28 +210,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.7.3.tgz",
-      "integrity": "sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.1.tgz",
+      "integrity": "sha512-tmQiQ2HvtzaeLqYGy3BemiPOSGPY4wCy1IW5zDWITKSs/s35WEd7Zij/hCxvUdAOzj6U3qnyaGbYXY91ortFEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.12.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.6.1",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -254,9 +239,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -264,22 +249,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -305,14 +290,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -322,13 +307,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -376,29 +361,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -408,9 +393,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -428,9 +413,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -448,27 +433,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -533,13 +518,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -575,13 +560,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -701,13 +686,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -717,33 +702,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -751,14 +736,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -782,9 +767,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -801,9 +786,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -811,24 +796,31 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -837,9 +829,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -850,19 +842,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -873,20 +868,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -897,9 +892,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -913,17 +908,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -941,19 +936,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -962,9 +944,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -975,9 +957,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -988,9 +970,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -998,13 +980,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1012,41 +994,41 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1077,70 +1059,14 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=18"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1160,6 +1086,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1172,6 +1108,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -1227,9 +1177,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1456,10 +1406,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1471,7 +1428,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1490,9 +1447,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1631,6 +1588,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1660,9 +1628,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1671,9 +1639,9 @@
       }
     },
     "node_modules/@keeper-security/secrets-manager-core": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@keeper-security/secrets-manager-core/-/secrets-manager-core-17.2.0.tgz",
-      "integrity": "sha512-yfE6K4aXKaJBuFeCdZUivNF9qzwXgFWBhfFYN/6pczsikGbf750I4IamvbF8XUuWm1p/J+hc5jP3oVPXj2d9eQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@keeper-security/secrets-manager-core/-/secrets-manager-core-17.4.0.tgz",
+      "integrity": "sha512-KjJKPlQiHK00ft2lhirLSyZHv1qLui4oD0AkMTFXXC4BpNlQFwR/CLTtJc4dLTJ3tKoA5aGs8A8l4sNqcNPUxQ==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1796,9 +1764,9 @@
       }
     },
     "node_modules/@secretlint/formatter/node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1900,9 +1868,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1940,28 +1908,28 @@
       }
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.2.2.tgz",
-      "integrity": "sha512-9ByYNzWV8tpz6BFaRzeRzIov8dkbSZu9q7IWqEIfmRuLWb2qbI/5gTvKcoWT1HYs4XM7IZ8TKSXcuPvMb6eorA==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
+      "integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.2.2.tgz",
-      "integrity": "sha512-oMVaMJ3exFvXhCj3AqmCbLaeYrTNLqaJnLJMIlmnRM3/kZdxvku4OYdaDzgtlI194cVxamOY5AbHBBVnY79kEg==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
+      "integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.2.2",
-        "@textlint/resolver": "15.2.2",
-        "@textlint/types": "15.2.2",
+        "@textlint/module-interop": "15.7.1",
+        "@textlint/resolver": "15.7.1",
+        "@textlint/types": "15.7.1",
         "chalk": "^4.1.2",
-        "debug": "^4.4.1",
-        "js-yaml": "^3.14.1",
-        "lodash": "^4.17.21",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "lodash": "^4.18.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
@@ -2000,27 +1968,27 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.2.2.tgz",
-      "integrity": "sha512-2rmNcWrcqhuR84Iio1WRzlc4tEoOMHd6T7urjtKNNefpTt1owrTJ9WuOe60yD3FrTW0J/R0ux5wxUbP/eaeFOA==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
+      "integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/resolver": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.2.2.tgz",
-      "integrity": "sha512-4hGWjmHt0y+5NAkoYZ8FvEkj8Mez9TqfbTm3BPjoV32cIfEixl2poTOgapn1rfm73905GSO3P1jiWjmgvii13Q==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
+      "integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/types": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.2.2.tgz",
-      "integrity": "sha512-X2BHGAR3yXJsCAjwYEDBIk9qUDWcH4pW61ISfmtejau+tVqKtnbbvEZnMTb6mWgKU1BvTmftd5DmB1XVDUtY3g==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
+      "integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.2"
+        "@textlint/ast-node-types": "15.7.1"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2091,9 +2059,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2160,9 +2128,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2191,16 +2159,16 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.103.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.103.0.tgz",
-      "integrity": "sha512-o4hanZAQdNfsKecexq9L3eHICd0AAvdbLk6hA60UzGXbGH/q8b/9xv2RgR7vV3ZcHuyKVq7b37IGd/+gM4Tu+Q==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2215,21 +2183,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
-      "integrity": "sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/type-utils": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/type-utils": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2239,23 +2206,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.41.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.59.4",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.41.0.tgz",
-      "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2265,20 +2232,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.41.0.tgz",
-      "integrity": "sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.41.0",
-        "@typescript-eslint/types": "^8.41.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.59.4",
+        "@typescript-eslint/types": "^8.59.4",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2288,18 +2255,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz",
-      "integrity": "sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2310,9 +2277,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz",
-      "integrity": "sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2323,21 +2290,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.41.0.tgz",
-      "integrity": "sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2347,14 +2314,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.41.0.tgz",
-      "integrity": "sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2366,22 +2333,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz",
-      "integrity": "sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.41.0",
-        "@typescript-eslint/tsconfig-utils": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.59.4",
+        "@typescript-eslint/tsconfig-utils": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2391,20 +2357,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.41.0.tgz",
-      "integrity": "sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2414,19 +2380,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz",
-      "integrity": "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.59.4",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2437,22 +2403,22 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
-      "integrity": "sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2487,6 +2453,61 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@vscode/test-cli/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vscode/test-cli/node_modules/glob": {
       "version": "10.5.0",
@@ -2533,6 +2554,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vscode/test-cli/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@vscode/test-cli/node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -2548,6 +2585,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@vscode/test-electron": {
@@ -2568,17 +2641,17 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.6.0.tgz",
-      "integrity": "sha512-u2ZoMfymRNJb14aHNawnXJtXHLXDVKc1oKZaH4VELKT/9iWKRVgtQOdwxCgtwSxJoqYvuK4hGlBWQJ05wxADhg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
+      "integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.1.0",
-        "@secretlint/node": "^10.1.1",
-        "@secretlint/secretlint-formatter-sarif": "^10.1.1",
-        "@secretlint/secretlint-rule-no-dotenv": "^10.1.1",
-        "@secretlint/secretlint-rule-preset-recommend": "^10.1.1",
+        "@secretlint/node": "^10.1.2",
+        "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+        "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+        "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
         "@vscode/vsce-sign": "^2.0.0",
         "azure-devops-node-api": "^12.5.0",
         "chalk": "^4.1.2",
@@ -2595,13 +2668,13 @@
         "minimatch": "^3.0.3",
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
-        "secretlint": "^10.1.1",
+        "secretlint": "^10.1.2",
         "semver": "^7.5.2",
         "tmp": "^0.2.3",
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
-        "yauzl": "^2.3.1",
+        "yauzl": "^3.2.1",
         "yazl": "^2.2.2"
       },
       "bin": {
@@ -2615,28 +2688,28 @@
       }
     },
     "node_modules/@vscode/vsce-sign": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.6.tgz",
-      "integrity": "sha512-j9Ashk+uOWCDHYDxgGsqzKq5FXW9b9MW7QqOIYZ8IYpneJclWTBeHZz2DJCSKQgo+JAqNcaRRE1hzIx0dswqAw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "optionalDependencies": {
-        "@vscode/vsce-sign-alpine-arm64": "2.0.5",
-        "@vscode/vsce-sign-alpine-x64": "2.0.5",
-        "@vscode/vsce-sign-darwin-arm64": "2.0.5",
-        "@vscode/vsce-sign-darwin-x64": "2.0.5",
-        "@vscode/vsce-sign-linux-arm": "2.0.5",
-        "@vscode/vsce-sign-linux-arm64": "2.0.5",
-        "@vscode/vsce-sign-linux-x64": "2.0.5",
-        "@vscode/vsce-sign-win32-arm64": "2.0.5",
-        "@vscode/vsce-sign-win32-x64": "2.0.5"
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
       }
     },
     "node_modules/@vscode/vsce-sign-alpine-arm64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.5.tgz",
-      "integrity": "sha512-XVmnF40APwRPXSLYA28Ye+qWxB25KhSVpF2eZVtVOs6g7fkpOxsVnpRU1Bz2xG4ySI79IRuapDJoAQFkoOgfdQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
       "cpu": [
         "arm64"
       ],
@@ -2648,9 +2721,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-alpine-x64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.5.tgz",
-      "integrity": "sha512-JuxY3xcquRsOezKq6PEHwCgd1rh1GnhyH6urVEWUzWn1c1PC4EOoyffMD+zLZtFuZF5qR1I0+cqDRNKyPvpK7Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
       "cpu": [
         "x64"
       ],
@@ -2662,9 +2735,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-darwin-arm64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.5.tgz",
-      "integrity": "sha512-z2Q62bk0ptADFz8a0vtPvnm6vxpyP3hIEYMU+i1AWz263Pj8Mc38cm/4sjzxu+LIsAfhe9HzvYNS49lV+KsatQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
       "cpu": [
         "arm64"
       ],
@@ -2676,9 +2749,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-darwin-x64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.5.tgz",
-      "integrity": "sha512-ma9JDC7FJ16SuPXlLKkvOD2qLsmW/cKfqK4zzM2iJE1PbckF3BlR08lYqHV89gmuoTpYB55+z8Y5Fz4wEJBVDA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
       "cpu": [
         "x64"
       ],
@@ -2690,9 +2763,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-linux-arm": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.5.tgz",
-      "integrity": "sha512-cdCwtLGmvC1QVrkIsyzv01+o9eR+wodMJUZ9Ak3owhcGxPRB53/WvrDHAFYA6i8Oy232nuen1YqWeEohqBuSzA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
       "cpu": [
         "arm"
       ],
@@ -2704,9 +2777,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-linux-arm64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.5.tgz",
-      "integrity": "sha512-Hr1o0veBymg9SmkCqYnfaiUnes5YK6k/lKFA5MhNmiEN5fNqxyPUCdRZMFs3Ajtx2OFW4q3KuYVRwGA7jdLo7Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
       "cpu": [
         "arm64"
       ],
@@ -2718,9 +2791,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-linux-x64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.5.tgz",
-      "integrity": "sha512-XLT0gfGMcxk6CMRLDkgqEPTyG8Oa0OFe1tPv2RVbphSOjFWJwZgK3TYWx39i/7gqpDHlax0AP6cgMygNJrA6zg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
       "cpu": [
         "x64"
       ],
@@ -2732,9 +2805,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-win32-arm64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.5.tgz",
-      "integrity": "sha512-hco8eaoTcvtmuPhavyCZhrk5QIcLiyAUhEso87ApAWDllG7djIrWiOCtqn48k4pHz+L8oCQlE0nwNHfcYcxOPw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
       "cpu": [
         "arm64"
       ],
@@ -2746,9 +2819,9 @@
       ]
     },
     "node_modules/@vscode/vsce-sign-win32-x64": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.5.tgz",
-      "integrity": "sha512-1ixKFGM2FwM+6kQS2ojfY3aAelICxjiCzeg4nTHpkeU1Tfs4RC+lVLrgq5NwcBC7ZLr6UfY3Ct3D6suPeOf7BQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
       "cpu": [
         "x64"
       ],
@@ -2759,10 +2832,17 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/vsce/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2771,9 +2851,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3006,9 +3086,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3052,9 +3132,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3116,9 +3196,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3159,14 +3239,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3323,11 +3400,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3350,6 +3430,19 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3424,13 +3517,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3454,9 +3550,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3474,10 +3570,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001737",
-        "electron-to-chromium": "^1.5.211",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3653,9 +3750,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -3714,9 +3811,9 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3725,11 +3822,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -3890,24 +3987,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -3945,9 +4024,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4090,9 +4169,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4138,9 +4217,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4181,9 +4260,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4198,9 +4277,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4234,9 +4313,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -4255,9 +4334,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4334,9 +4413,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4395,9 +4474,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.359",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.359.tgz",
+      "integrity": "sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw==",
       "dev": true,
       "license": "ISC"
     },
@@ -4447,14 +4526,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "version": "5.21.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.4.tgz",
+      "integrity": "sha512-wE4fDO8OjJhrPFH69HUQStq5oKvGRTNXEyW+k5C/pUQLASSsTu7obd2V3GvCDgPcY9AWjhJ4jz9Kh7iRvrxhJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -4474,9 +4553,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4500,9 +4579,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4530,9 +4609,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4589,26 +4668,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.34.0.tgz",
-      "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.1",
-        "@eslint/core": "^0.15.2",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.34.0",
-        "@eslint/plugin-kit": "^0.3.5",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -4627,7 +4705,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4680,9 +4758,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4696,10 +4774,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4751,9 +4836,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4809,9 +4894,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4971,9 +5056,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -4998,9 +5083,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5015,16 +5100,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5095,9 +5170,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5119,9 +5194,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5144,9 +5219,9 @@
       "optional": true
     },
     "node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5211,9 +5286,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5338,22 +5413,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -5421,17 +5480,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5490,9 +5542,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5533,9 +5585,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -5548,14 +5600,14 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5703,9 +5755,9 @@
       }
     },
     "node_modules/index-to-position": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
-      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5773,13 +5825,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5889,6 +5941,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -5939,9 +6001,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6081,13 +6143,13 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "@isaacs/cliui": "^9.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -6250,10 +6312,17 @@
         }
       }
     },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6265,7 +6334,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6284,9 +6353,9 @@
       }
     },
     "node_modules/jest-config/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6592,10 +6661,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6607,7 +6683,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6626,9 +6702,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6779,14 +6855,13 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -6854,9 +6929,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6867,13 +6942,13 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -6903,9 +6978,9 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6915,13 +6990,13 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.2",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -7020,13 +7095,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -7046,9 +7125,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7186,9 +7265,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7202,13 +7281,6 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -7332,16 +7404,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7358,11 +7430,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -7376,29 +7448,30 @@
       "optional": true
     },
     "node_modules/mocha": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
-      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -7411,12 +7484,53 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/mocha/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+    "node_modules/mocha/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mocha/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/mocha/node_modules/chokidar": {
       "version": "4.0.3",
@@ -7433,6 +7547,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/mocha/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha/node_modules/glob": {
       "version": "10.5.0",
@@ -7456,22 +7577,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/mocha/node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -7488,19 +7593,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/mocha/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -7509,16 +7601,19 @@
       "license": "ISC"
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/path-scurry": {
@@ -7552,6 +7647,24 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/mocha/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7566,6 +7679,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -7605,9 +7736,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.75.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -7634,16 +7765,16 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-sarif-builder": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
-      "integrity": "sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7651,7 +7782,7 @@
         "fs-extra": "^11.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/normalize-package-data": {
@@ -7826,9 +7957,9 @@
       }
     },
     "node_modules/ora/node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7839,9 +7970,9 @@
       }
     },
     "node_modules/ora/node_modules/emoji-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -7939,9 +8070,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8118,9 +8249,9 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -8128,18 +8259,18 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -8172,9 +8303,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8277,6 +8408,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8312,9 +8444,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8377,9 +8509,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8426,9 +8558,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8462,16 +8594,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -8490,36 +8612,16 @@
       }
     },
     "node_modules/rc-config-loader": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
-      "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
-        "js-yaml": "^4.1.0",
-        "json5": "^2.2.2",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/rc-config-loader/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/rc/node_modules/strip-json-comments": {
@@ -8687,13 +8789,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -8795,9 +8898,9 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8860,16 +8963,19 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8909,9 +9015,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8922,13 +9028,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {
@@ -8995,14 +9101,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9198,9 +9304,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -9379,13 +9485,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9558,9 +9664,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
-      "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9637,9 +9743,9 @@
       }
     },
     "node_modules/terminal-link/node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9653,14 +9759,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -9672,16 +9778,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
+      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -9695,10 +9800,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -9770,10 +9902,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9785,7 +9924,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9804,9 +9943,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9837,6 +9976,54 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmp": {
@@ -9870,9 +10057,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9883,19 +10070,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
-      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -9912,7 +10099,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -9949,9 +10136,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.5.4",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
-      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
+      "version": "9.5.7",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
+      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10059,9 +10246,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10094,16 +10281,16 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
-      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10141,9 +10328,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -10195,16 +10382,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10255,9 +10432,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10269,9 +10446,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.101.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
-      "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10281,25 +10458,24 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.3",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.1",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -10376,9 +10552,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10409,10 +10585,21 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10473,25 +10660,25 @@
       "license": "MIT"
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -10539,42 +10726,27 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -10721,14 +10893,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yazl": {

--- a/package.json
+++ b/package.json
@@ -186,5 +186,11 @@
   "overrides": {
     "diff": "^8.0.3",
     "serialize-javascript": "^7.0.5"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "Keeper Security accesses local CLI binaries and reads .env files; untrusted workspaces could include malicious .env files or workspace-relative tools that hijack the extension's CLI calls."
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -176,11 +176,15 @@
     "ts-jest": "^29.1.2",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
-    "webpack": "^5.99.7",
+    "webpack": "^5.105.2",
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
     "@keeper-security/secrets-manager-core": "^17.2.0",
     "dotenv": "^17.2.0"
+  },
+  "overrides": {
+    "diff": "^8.0.3",
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ks-vscode",
   "displayName": "Keeper Security",
   "description": "Never commit secrets to your code again - secure them in your Keeper vault",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "publisher": "KeeperSecurityDev",
   "galleryBanner": {

--- a/src/commands/factories/handlerFactory.ts
+++ b/src/commands/factories/handlerFactory.ts
@@ -46,7 +46,7 @@ export class HandlerFactory {
       );
       handlers.set(
         COMMANDS.GET_VALUE_FROM_VAULT,
-        new CliGetValueHandler(spinner, cliService)
+        new CliGetValueHandler(spinner, cliService, storageManager)
       );
       handlers.set(
         COMMANDS.GENERATE_PASSWORD,

--- a/src/commands/handlers/base/baseGetValueHandler.ts
+++ b/src/commands/handlers/base/baseGetValueHandler.ts
@@ -17,7 +17,7 @@ export abstract class BaseGetValueHandler extends BaseCommandHandler {
   ): Promise<IRecordQuickPick | undefined> {
     return await window.showQuickPick(items, {
       ...commonQuickPickOptions,
-      title: BASE_HANDLER_MESSAGES.INPUT.QUICK_PICK_FOR_RECORDS_TITLE,
+      title: BASE_HANDLER_MESSAGES.INPUT.QUICK_PICK_FOR_RECORDS_TITLE + ' (Showing compatible records)',
       placeHolder:
         BASE_HANDLER_MESSAGES.INPUT.QUICK_PICK_FOR_RECORDS_PLACEHOLDER,
     });

--- a/src/commands/handlers/base/baseRunSecurelyHandler.ts
+++ b/src/commands/handlers/base/baseRunSecurelyHandler.ts
@@ -5,6 +5,7 @@ import {
   commonInputBoxOptions,
   commonQuickPickOptions,
   isEnvironmentFile,
+  assertSafeKeeperNotationEnvValue,
   parseKeeperReference,
   StatusBarSpinner,
   validateKeeperReference,
@@ -275,6 +276,17 @@ export abstract class BaseRunSecurelyHandler extends BaseCommandHandler {
     >();
 
     for (const [key, value] of Object.entries(envConfig)) {
+      if (typeof value === 'string' && value.startsWith('keeper://')) {
+        try {
+          assertSafeKeeperNotationEnvValue(value, key);
+        } catch (error) {
+          window.showErrorMessage(
+            BASE_HANDLER_MESSAGES.ERROR.INVALID_KEEPER_REFERENCE_IN_ENV
+          );
+          throw error;
+        }
+      }
+
       if (typeof value === 'string' && validateKeeperReference(value)) {
         const parsedRef = parseKeeperReference(value);
         if (!parsedRef) {

--- a/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
+++ b/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
@@ -3,7 +3,7 @@ import { createKeeperReference, StatusBarSpinner } from '../../../utils/helper';
 import { BaseGeneratePasswordHandler } from '../base/baseGeneratePasswordHandler';
 import { logger } from '../../../utils/logger';
 import {
-  CLI_SOURCE_KEEPER_DRIVE,
+  CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
@@ -66,9 +66,9 @@ export class CliGeneratePasswordHandler extends BaseGeneratePasswordHandler {
       // Dynamically determine the record command to execute based on the current storage source
       let recordCommandToExecute = 'record-add';
 
-      // if currentStorage source is KeeperDrive, then use kd-record-add command or default record-add command
-      if(currentStorage?.source === CLI_SOURCE_KEEPER_DRIVE) {
-        recordCommandToExecute = 'kd-record-add';
+      // if currentStorage source is KeeperDrive, then use nsf-record-add command or default record-add command
+      if(currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER) {
+        recordCommandToExecute = 'nsf-record-add';
       }
 
       // if currentStorage is not "My Vault", then add folder to args

--- a/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
+++ b/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
@@ -3,6 +3,7 @@ import { createKeeperReference, StatusBarSpinner } from '../../../utils/helper';
 import { BaseGeneratePasswordHandler } from '../base/baseGeneratePasswordHandler';
 import { logger } from '../../../utils/logger';
 import {
+  CLI_SOURCE_KEEPER_DRIVE,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
@@ -62,13 +63,21 @@ export class CliGeneratePasswordHandler extends BaseGeneratePasswordHandler {
         `"password"=$GEN`,
       ];
 
+      // Dynamically determine the record command to execute based on the current storage source
+      let recordCommandToExecute = 'record-add';
+
+      // if currentStorage source is KeeperDrive, then use kd-record-add command or default record-add command
+      if(currentStorage?.source === CLI_SOURCE_KEEPER_DRIVE) {
+        recordCommandToExecute = 'kd-record-add';
+      }
+
       // if currentStorage is not "My Vault", then add folder to args
       if (currentStorage?.folderUid !== '/') {
         args.push(`--folder="${currentStorage?.folderUid}"`);
       }
 
       const recordUid = await this.cliService.executeCommanderCommand(
-        'record-add',
+        recordCommandToExecute, 
         args
       );
 

--- a/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
+++ b/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
@@ -3,7 +3,6 @@ import { createKeeperReference, StatusBarSpinner } from '../../../utils/helper';
 import { BaseGeneratePasswordHandler } from '../base/baseGeneratePasswordHandler';
 import { logger } from '../../../utils/logger';
 import {
-  CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
@@ -15,6 +14,7 @@ import {
   CLI_LOGGER_ERROR_MESSAGES,
 } from '../../../utils/cli-messages';
 import { CliStorageManager } from '../../storage/cliStorageManager';
+import { resolveRecordAddCommand } from '../../utils/cliRecordCommandResolver';
 
 export class CliGeneratePasswordHandler extends BaseGeneratePasswordHandler {
   constructor(
@@ -53,23 +53,26 @@ export class CliGeneratePasswordHandler extends BaseGeneratePasswordHandler {
         return;
       }
 
-      this.spinner.show(CLI_INFO_MESSAGES.GENERATING_PASSWORD);
-
       const currentStorage = this.storageManager.getCurrentStorage();
+
+      const recordCommandToExecute =
+        await resolveRecordAddCommand(currentStorage);
+      if (!recordCommandToExecute) {
+        logger.logDebug(
+          this.constructor.name +
+            ': ' +
+            CLI_LOGGER_DEBUG_MESSAGES.USER_CANCELLED_PERMISSION_MODEL_SELECTION
+        );
+        return;
+      }
+
+      this.spinner.show(CLI_INFO_MESSAGES.GENERATING_PASSWORD);
 
       const args = [
         `--title="${recordName}"`,
         `--record-type=${KEEPER_RECORD_TYPES.LOGIN}`,
         `"password"=$GEN`,
       ];
-
-      // Dynamically determine the record command to execute based on the current storage source
-      let recordCommandToExecute = 'record-add';
-
-      // if currentStorage source is KeeperDrive, then use nsf-record-add command or default record-add command
-      if(currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER) {
-        recordCommandToExecute = 'nsf-record-add';
-      }
 
       // if currentStorage is not "My Vault", then add folder to args
       if (currentStorage?.folderUid !== '/') {

--- a/src/commands/handlers/cli/cliGetValueHandler.ts
+++ b/src/commands/handlers/cli/cliGetValueHandler.ts
@@ -1,7 +1,12 @@
 import { window } from 'vscode';
 import { logger } from '../../../utils/logger';
 import { BaseGetValueHandler } from '../base/baseGetValueHandler';
-import { CLI_FOLDER_SOURCE_LEGACY, CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER, CLI_RECORD_CATEGORY_CLASSIC, KEEPER_NOTATION_FIELD_TYPES } from '../../../utils/constants';
+import {
+  CLI_FOLDER_SOURCE_LEGACY,
+  CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+  CLI_RECORD_CATEGORY_CLASSIC,
+  KEEPER_NOTATION_FIELD_TYPES,
+} from '../../../utils/constants';
 import {
   createKeeperReference,
   safeJsonParse,
@@ -16,7 +21,10 @@ import {
   CLI_LOGGER_ERROR_MESSAGES,
   CLI_SUCCESS_MESSAGES,
 } from '../../../utils/cli-messages';
-import { ICliListRecordResponse, ICliNsfListRecordResponse } from '../../../types';
+import {
+  ICliListRecordResponse,
+  ICliNsfListRecordResponse,
+} from '../../../types';
 import { CliStorageManager } from '../../storage/cliStorageManager';
 
 export class CliGetValueHandler extends BaseGetValueHandler {
@@ -65,18 +73,17 @@ export class CliGetValueHandler extends BaseGetValueHandler {
       const currentStorage = this.storageManager.getCurrentStorage();
       let processedAllRecords: IRecordQuickPick[] = [];
 
-      if (currentStorage?.folderUid === '/') {
-        // My Vault: fetch both NSF and classic records. CLI service blocks parallel
-        // commands (see `isExecutingCommand` in services/cli.ts), so run sequentially.
-        const nsfQuickPickItems = await this.fetchAndProcessNsfRecords();
-        const classicQuickPickItems = await this.fetchAndProcessClassicRecords();
-        processedAllRecords = [...nsfQuickPickItems, ...classicQuickPickItems];
-      } else if (
-        currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER
-      ) {
+      if (currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER) {
         processedAllRecords = await this.fetchAndProcessNsfRecords();
       } else if (currentStorage?.source === CLI_FOLDER_SOURCE_LEGACY) {
         processedAllRecords = await this.fetchAndProcessClassicRecords();
+      } else {
+        // My Vault: fetch both NSF and classic records. CLI service blocks parallel
+        // commands (see `isExecutingCommand` in services/cli.ts), so run sequentially.
+        const nsfQuickPickItems = await this.fetchAndProcessNsfRecords();
+        const classicQuickPickItems =
+          await this.fetchAndProcessClassicRecords();
+        processedAllRecords = [...nsfQuickPickItems, ...classicQuickPickItems];
       }
 
       logger.logDebug(
@@ -230,7 +237,7 @@ export class CliGetValueHandler extends BaseGetValueHandler {
     );
 
     return nsfRecords.map((record) => ({
-      label: `${record.Title} (Nested)`, 
+      label: `${record.Title} (Nested)`,
       value: record.UID,
     }));
   }
@@ -250,7 +257,9 @@ export class CliGetValueHandler extends BaseGetValueHandler {
     );
 
     return classicRecords
-      .filter((record) => record.record_category === CLI_RECORD_CATEGORY_CLASSIC)
+      .filter(
+        (record) => record.record_category === CLI_RECORD_CATEGORY_CLASSIC
+      )
       .map((record) => ({
         label: `${record.title} (Classic)`,
         value: record.record_uid,

--- a/src/commands/handlers/cli/cliGetValueHandler.ts
+++ b/src/commands/handlers/cli/cliGetValueHandler.ts
@@ -256,9 +256,10 @@ export class CliGetValueHandler extends BaseGetValueHandler {
       []
     );
 
+    // filter records to only include classic records
     return classicRecords
       .filter(
-        (record) => record.record_category === CLI_RECORD_CATEGORY_CLASSIC
+        (record) => record.record_category.toLowerCase() === CLI_RECORD_CATEGORY_CLASSIC
       )
       .map((record) => ({
         label: `${record.title} (Classic)`,

--- a/src/commands/handlers/cli/cliGetValueHandler.ts
+++ b/src/commands/handlers/cli/cliGetValueHandler.ts
@@ -16,7 +16,7 @@ import {
   CLI_LOGGER_ERROR_MESSAGES,
   CLI_SUCCESS_MESSAGES,
 } from '../../../utils/cli-messages';
-import { ICliListCommandResponse } from '../../../types';
+import { ICliListRecordResponse } from '../../../types';
 
 export class CliGetValueHandler extends BaseGetValueHandler {
   constructor(
@@ -43,7 +43,7 @@ export class CliGetValueHandler extends BaseGetValueHandler {
           ': ' +
           CLI_LOGGER_DEBUG_MESSAGES.SYNCING_DOWN_LATEST_RECORDS_FROM_VAULT
       );
-      await this.cliService.executeCommanderCommand('sync-down');
+      await this.cliService.executeCommanderCommand('sync-down --force');
 
       // List available records
       logger.logDebug(
@@ -51,11 +51,14 @@ export class CliGetValueHandler extends BaseGetValueHandler {
           ': ' +
           CLI_LOGGER_DEBUG_MESSAGES.EXECUTING_LIST_COMMAND_TO_GET_AVAILABLE_RECORDS
       );
+
+      // TODO: 1. run nsf-list --records --format json if selected storage is nested share folder else current implementation
+      // 2. for record display title add NSF or Legacy suffix
       const secrets = await this.cliService.executeCommanderCommand('list', [
         '--format=json',
       ]);
       // Use safe parser that cleans output first
-      const allRecords: ICliListCommandResponse[] = safeJsonParse(secrets, []);
+      const allRecords: ICliListRecordResponse[] = safeJsonParse(secrets, []);
       logger.logDebug(
         this.constructor.name +
           ': ' +
@@ -82,7 +85,7 @@ export class CliGetValueHandler extends BaseGetValueHandler {
        */
       const processedAllRecords: IRecordQuickPick[] = allRecords.map(
         (record) => ({
-          label: record.title,
+          label: `${record.title} (${record.record_category})`,
           value: record.record_uid,
         })
       );

--- a/src/commands/handlers/cli/cliGetValueHandler.ts
+++ b/src/commands/handlers/cli/cliGetValueHandler.ts
@@ -1,7 +1,7 @@
 import { window } from 'vscode';
 import { logger } from '../../../utils/logger';
 import { BaseGetValueHandler } from '../base/baseGetValueHandler';
-import { KEEPER_NOTATION_FIELD_TYPES } from '../../../utils/constants';
+import { CLI_FOLDER_SOURCE_LEGACY, CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER, CLI_RECORD_CATEGORY_CLASSIC, KEEPER_NOTATION_FIELD_TYPES } from '../../../utils/constants';
 import {
   createKeeperReference,
   safeJsonParse,
@@ -16,12 +16,14 @@ import {
   CLI_LOGGER_ERROR_MESSAGES,
   CLI_SUCCESS_MESSAGES,
 } from '../../../utils/cli-messages';
-import { ICliListRecordResponse } from '../../../types';
+import { ICliListRecordResponse, ICliNsfListRecordResponse } from '../../../types';
+import { CliStorageManager } from '../../storage/cliStorageManager';
 
 export class CliGetValueHandler extends BaseGetValueHandler {
   constructor(
     private spinner: StatusBarSpinner,
-    private cliService: CliService
+    private cliService: CliService,
+    private storageManager: CliStorageManager
   ) {
     super();
   }
@@ -52,23 +54,41 @@ export class CliGetValueHandler extends BaseGetValueHandler {
           CLI_LOGGER_DEBUG_MESSAGES.EXECUTING_LIST_COMMAND_TO_GET_AVAILABLE_RECORDS
       );
 
-      // TODO: 1. run nsf-list --records --format json if selected storage is nested share folder else current implementation
-      // 2. for record display title add NSF or Legacy suffix
-      const secrets = await this.cliService.executeCommanderCommand('list', [
-        '--format=json',
-      ]);
-      // Use safe parser that cleans output first
-      const allRecords: ICliListRecordResponse[] = safeJsonParse(secrets, []);
+      /*
+          IF current storage is "My Vault" (root folder), run BOTH nsf-list and list
+          and combine their records into a single quick pick.
+          IF NSF folder is selected, then run nsf-list --records --format json
+          IF Legacy folder is selected, then run list --format json and filter
+          only classic records.
+      */
+
+      const currentStorage = this.storageManager.getCurrentStorage();
+      let processedAllRecords: IRecordQuickPick[] = [];
+
+      if (currentStorage?.folderUid === '/') {
+        // My Vault: fetch both NSF and classic records. CLI service blocks parallel
+        // commands (see `isExecutingCommand` in services/cli.ts), so run sequentially.
+        const nsfQuickPickItems = await this.fetchAndProcessNsfRecords();
+        const classicQuickPickItems = await this.fetchAndProcessClassicRecords();
+        processedAllRecords = [...nsfQuickPickItems, ...classicQuickPickItems];
+      } else if (
+        currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER
+      ) {
+        processedAllRecords = await this.fetchAndProcessNsfRecords();
+      } else if (currentStorage?.source === CLI_FOLDER_SOURCE_LEGACY) {
+        processedAllRecords = await this.fetchAndProcessClassicRecords();
+      }
+
       logger.logDebug(
         this.constructor.name +
           ': ' +
           CLI_LOGGER_DEBUG_MESSAGES.RETRIEVED_RECORDS_FROM_VAULT +
-          `- ${allRecords.length}`
+          `- ${processedAllRecords.length}`
       );
 
       this.spinner.hide();
 
-      if (!allRecords || allRecords.length === 0) {
+      if (processedAllRecords.length === 0) {
         logger.logDebug(
           this.constructor.name +
             ': ' +
@@ -77,18 +97,6 @@ export class CliGetValueHandler extends BaseGetValueHandler {
         window.showInformationMessage(CLI_SUCCESS_MESSAGES.NO_RECORDS_FOUND);
         return;
       }
-
-      /**
-       * Process all records to show in quick pick
-       * label: record title
-       * value: record uid
-       */
-      const processedAllRecords: IRecordQuickPick[] = allRecords.map(
-        (record) => ({
-          label: `${record.title} (${record.record_category})`,
-          value: record.record_uid,
-        })
-      );
 
       const selectedRecord =
         await this.showQuickPickForRecords(processedAllRecords);
@@ -205,5 +213,47 @@ export class CliGetValueHandler extends BaseGetValueHandler {
     } finally {
       this.spinner.hide();
     }
+  }
+
+  /**
+   * Fetches records from a nested share folder via `nsf-list --records --format=json`
+   * and maps them into quick-pick items.
+   */
+  private async fetchAndProcessNsfRecords(): Promise<IRecordQuickPick[]> {
+    const nsfRecordsRaw = await this.cliService.executeCommanderCommand(
+      'nsf-list',
+      ['--records', '--format=json']
+    );
+    const nsfRecords: ICliNsfListRecordResponse[] = safeJsonParse(
+      nsfRecordsRaw,
+      []
+    );
+
+    return nsfRecords.map((record) => ({
+      label: `${record.Title} (Nested)`, 
+      value: record.UID,
+    }));
+  }
+
+  /**
+   * Fetches records from the classic vault via `list --format=json`, filters to
+   * `Classic` records only, and maps them into quick-pick items.
+   */
+  private async fetchAndProcessClassicRecords(): Promise<IRecordQuickPick[]> {
+    const classicRecordsRaw = await this.cliService.executeCommanderCommand(
+      'list',
+      ['--format=json']
+    );
+    const classicRecords: ICliListRecordResponse[] = safeJsonParse(
+      classicRecordsRaw,
+      []
+    );
+
+    return classicRecords
+      .filter((record) => record.record_category === CLI_RECORD_CATEGORY_CLASSIC)
+      .map((record) => ({
+        label: `${record.title} (Classic)`,
+        value: record.record_uid,
+      }));
   }
 }

--- a/src/commands/handlers/cli/cliSaveValueHandler.ts
+++ b/src/commands/handlers/cli/cliSaveValueHandler.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../utils/cli-messages';
 import { CliStorageManager } from '../../storage/cliStorageManager';
 import {
+  CLI_SOURCE_KEEPER_DRIVE,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
@@ -79,6 +80,14 @@ export class CliSaveValueHandler extends BaseSaveValueHandler {
 
       const currentStorage = this.storageManager.getCurrentStorage();
 
+      // Dynamically determine the record command to execute based on the current storage source
+      let recordCommandToExecute = 'record-add';
+
+      // if currentStorage source is KeeperDrive, then use kd-record-add command or default record-add command
+      if (currentStorage?.source === CLI_SOURCE_KEEPER_DRIVE) {
+        recordCommandToExecute = 'kd-record-add';
+      }
+
       /**
        *
        * [<FIELD_SET>][<FIELD_TYPE>][<FIELD_LABEL>]=[FIELD_VALUE]
@@ -100,7 +109,7 @@ export class CliSaveValueHandler extends BaseSaveValueHandler {
       }
 
       const recordUid = await this.cliService.executeCommanderCommand(
-        'record-add',
+        recordCommandToExecute,
         args
       );
 

--- a/src/commands/handlers/cli/cliSaveValueHandler.ts
+++ b/src/commands/handlers/cli/cliSaveValueHandler.ts
@@ -11,10 +11,10 @@ import {
 } from '../../../utils/cli-messages';
 import { CliStorageManager } from '../../storage/cliStorageManager';
 import {
-  CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
+import { resolveRecordAddCommand } from '../../utils/cliRecordCommandResolver';
 
 export class CliSaveValueHandler extends BaseSaveValueHandler {
   constructor(
@@ -76,17 +76,20 @@ export class CliSaveValueHandler extends BaseSaveValueHandler {
         return;
       }
 
-      this.spinner.show(CLI_INFO_MESSAGES.SAVING_SECRET);
-
       const currentStorage = this.storageManager.getCurrentStorage();
 
-      // Dynamically determine the record command to execute based on the current storage source
-      let recordCommandToExecute = 'record-add';
-
-      // if currentStorage source is KeeperDrive, then use nsf-record-add command or default record-add command
-      if (currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER) {
-        recordCommandToExecute = 'nsf-record-add';
+      const recordCommandToExecute =
+        await resolveRecordAddCommand(currentStorage);
+      if (!recordCommandToExecute) {
+        logger.logDebug(
+          this.constructor.name +
+            ': ' +
+            CLI_LOGGER_DEBUG_MESSAGES.USER_CANCELLED_PERMISSION_MODEL_SELECTION
+        );
+        return;
       }
+
+      this.spinner.show(CLI_INFO_MESSAGES.SAVING_SECRET);
 
       /**
        *

--- a/src/commands/handlers/cli/cliSaveValueHandler.ts
+++ b/src/commands/handlers/cli/cliSaveValueHandler.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../utils/cli-messages';
 import { CliStorageManager } from '../../storage/cliStorageManager';
 import {
-  CLI_SOURCE_KEEPER_DRIVE,
+  CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
@@ -83,9 +83,9 @@ export class CliSaveValueHandler extends BaseSaveValueHandler {
       // Dynamically determine the record command to execute based on the current storage source
       let recordCommandToExecute = 'record-add';
 
-      // if currentStorage source is KeeperDrive, then use kd-record-add command or default record-add command
-      if (currentStorage?.source === CLI_SOURCE_KEEPER_DRIVE) {
-        recordCommandToExecute = 'kd-record-add';
+      // if currentStorage source is KeeperDrive, then use nsf-record-add command or default record-add command
+      if (currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER) {
+        recordCommandToExecute = 'nsf-record-add';
       }
 
       /**

--- a/src/commands/storage/baseStorageManager.ts
+++ b/src/commands/storage/baseStorageManager.ts
@@ -2,7 +2,10 @@ import { ExtensionContext, QuickPickItem, window } from 'vscode';
 import { IFolder } from '../../types';
 import { logger } from '../../utils/logger';
 import { commonQuickPickOptions, StatusBarSpinner } from '../../utils/helper';
-import { BASE_HANDLER_MESSAGES } from '../../utils/constants';
+import {
+  BASE_HANDLER_MESSAGES,
+  CLI_SOURCE_KEEPER_DRIVE,
+} from '../../utils/constants';
 
 export abstract class BaseStorageManager {
   constructor(
@@ -205,8 +208,18 @@ export abstract class BaseStorageManager {
       (folder: IFolder) => {
         const isCurrentStorage =
           this.getCurrentStorage()?.folderUid === folder.folderUid;
+
+        const folderType =
+          folder?.source && folder.source !== ''
+            ? folder.source === CLI_SOURCE_KEEPER_DRIVE
+              ? '(Keeper Drive Folder)'
+              : '(Legacy Folder)'
+            : null;
+
         const response: QuickPickItem & { value: string } = {
-          label: isCurrentStorage ? `${folder.name} ✓` : folder.name,
+          label: isCurrentStorage
+            ? `${folder.name} ✓ ${folderType ?? ''}`
+            : `${folder.name} ${folderType ?? ''}`,
           value: folder.folderUid,
         };
         if (folder.folderPath && folder.folderPath !== '/') {

--- a/src/commands/storage/baseStorageManager.ts
+++ b/src/commands/storage/baseStorageManager.ts
@@ -4,7 +4,7 @@ import { logger } from '../../utils/logger';
 import { commonQuickPickOptions, StatusBarSpinner } from '../../utils/helper';
 import {
   BASE_HANDLER_MESSAGES,
-  CLI_SOURCE_KEEPER_DRIVE,
+  CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
 } from '../../utils/constants';
 
 export abstract class BaseStorageManager {
@@ -21,6 +21,10 @@ export abstract class BaseStorageManager {
 
   private async validateCurrentStorage(
     getAvailableFolders: () => Promise<{
+      availableFolders: IFolder[];
+      rootFolder: IFolder;
+    }>,
+    getFolderByUid?: (uid: string) => Promise<{
       availableFolders: IFolder[];
       rootFolder: IFolder;
     }>
@@ -60,7 +64,9 @@ export abstract class BaseStorageManager {
       return true;
     }
 
-    const { availableFolders } = await getAvailableFolders();
+    const availableFolders = getFolderByUid
+      ? (await getFolderByUid(currentStorage.folderUid)).availableFolders
+      : (await getAvailableFolders()).availableFolders;
 
     const folderExists = availableFolders.some(
       (folder) => folder.folderUid === currentStorage.folderUid
@@ -97,6 +103,10 @@ export abstract class BaseStorageManager {
     getAvailableFolders: () => Promise<{
       availableFolders: IFolder[];
       rootFolder: IFolder;
+    }>,
+    getFolderByUid?: (uid: string) => Promise<{
+      availableFolders: IFolder[];
+      rootFolder: IFolder;
     }>
   ): Promise<boolean> {
     // if currentStorage is not set, choose a folder
@@ -120,7 +130,7 @@ export abstract class BaseStorageManager {
       );
       // Validate current storage
       const isFolderExistsOnKeeperVault =
-        await this.validateCurrentStorage(getAvailableFolders);
+        await this.validateCurrentStorage(getAvailableFolders, getFolderByUid);
 
       if (!isFolderExistsOnKeeperVault) {
         logger.logDebug(
@@ -211,9 +221,9 @@ export abstract class BaseStorageManager {
 
         const folderType =
           folder?.source && folder.source !== ''
-            ? folder.source === CLI_SOURCE_KEEPER_DRIVE
-              ? '(Keeper Drive Folder)'
-              : '(Legacy Folder)'
+            ? folder.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER
+              ? '(Nested Share Folder)'
+              : '(Classic Folder)'
             : null;
 
         const response: QuickPickItem & { value: string } = {

--- a/src/commands/storage/cliStorageManager.ts
+++ b/src/commands/storage/cliStorageManager.ts
@@ -2,12 +2,13 @@ import { ExtensionContext } from 'vscode';
 import { BaseStorageManager } from './baseStorageManager';
 import { safeJsonParse, StatusBarSpinner } from '../../utils/helper';
 import {
+  ICliGetFolderResponse,
   ICliListFolderResponse,
   IFolder,
 } from '../../types';
 import { logger } from '../../utils/logger';
 import { CliService } from '../../services/cli';
-import { CLI_SOURCE_KEEPER_DRIVE } from '../../utils/constants';
+import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER } from '../../utils/constants';
 
 function parseParentUidFromDetails(details?: string): string | undefined {
   if (!details?.includes(', Parent:')) {
@@ -27,7 +28,8 @@ export class CliStorageManager extends BaseStorageManager {
 
   async ensureValidStorage(): Promise<boolean> {
     return await super.ensureValidStorage(
-      this.fetchAvailableFolders.bind(this)
+      this.fetchAvailableFolders.bind(this),
+      this.getFolderByUid.bind(this)
     );
   }
 
@@ -39,7 +41,7 @@ export class CliStorageManager extends BaseStorageManager {
     logger.logDebug(
       'CliStorageManager: Syncing down latest records from vault'
     );
-    await this.cliService.executeCommanderCommand('sync-down');
+    await this.cliService.executeCommanderCommand('sync-down --force');
 
     logger.logDebug('CliStorageManager: Sync down completed');
 
@@ -59,7 +61,7 @@ export class CliStorageManager extends BaseStorageManager {
       name: 'My Vault',
       parentUid: '/',
       folderPath: '/',
-      source: CLI_SOURCE_KEEPER_DRIVE,
+      source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
     };
 
     const foldersWithPaths = [
@@ -68,6 +70,58 @@ export class CliStorageManager extends BaseStorageManager {
     ];
     return {
       availableFolders: foldersWithPaths,
+      rootFolder,
+    };
+  }
+
+  // this method is used to get a folder by uid, it is used to validate the current storage when user selects a folder from the quick pick only
+  async getFolderByUid(uid: string): Promise<{
+    availableFolders: IFolder[];
+    rootFolder: IFolder;
+  }> {
+    // Sync-down the latest records from the vault
+    logger.logDebug(
+      'CliStorageManager: Syncing down latest records from vault'
+    );
+    await this.cliService.executeCommanderCommand('sync-down --force');
+
+    logger.logDebug('CliStorageManager: Sync down completed');
+
+    logger.logDebug('Fetching folder by uid from Keeper vault');
+
+    const folderResponse = await this.cliService.executeCommanderCommand(
+      'get',
+      [`${uid}`, '--format=json']
+    );
+
+    const parsedFolder: ICliGetFolderResponse[] = safeJsonParse(
+      folderResponse,
+      []
+    );
+    logger.logDebug(`Retrieved folder by uid (${uid}) from vault`);
+
+    const rootFolder: IFolder = {
+      folderUid: '/',
+      name: 'My Vault',
+      parentUid: '/',
+      folderPath: '/',
+      source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+    };
+
+    const updatedParsedFolder = parsedFolder.map((folder) => {
+      // in below return we dont care about parentUid, folderPath, source because we are only using folderUid to check if the folder is valid or not
+      // So those fields are set to empty string and CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER
+      return {
+        folderUid : folder.shared_folder_uid ? folder.shared_folder_uid : folder.folder_uid,
+        name: folder.name,
+        parentUid: "",
+        folderPath: '',
+        source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+      };
+    });
+
+    return {
+      availableFolders: updatedParsedFolder,
       rootFolder,
     };
   }

--- a/src/commands/storage/cliStorageManager.ts
+++ b/src/commands/storage/cliStorageManager.ts
@@ -7,6 +7,14 @@ import {
 } from '../../types';
 import { logger } from '../../utils/logger';
 import { CliService } from '../../services/cli';
+import { CLI_SOURCE_KEEPER_DRIVE } from '../../utils/constants';
+
+function parseParentUidFromDetails(details?: string): string | undefined {
+  if (!details?.includes(', Parent:')) {
+    return undefined;
+  }
+  return details.split(', Parent:')[1]?.trim();
+}
 
 export class CliStorageManager extends BaseStorageManager {
   constructor(
@@ -51,6 +59,7 @@ export class CliStorageManager extends BaseStorageManager {
       name: 'My Vault',
       parentUid: '/',
       folderPath: '/',
+      source: CLI_SOURCE_KEEPER_DRIVE,
     };
 
     const foldersWithPaths = [
@@ -65,30 +74,30 @@ export class CliStorageManager extends BaseStorageManager {
 
   resolveFolderPaths(folders: ICliListFolderResponse[]): IFolder[] {
     logger.logDebug(`Resolving paths for ${folders.length} folders`);
-    // Map folderUid to folder for quick lookup
     const folderMap = new Map<string, ICliListFolderResponse>();
-    folders.forEach((folder) => folderMap.set(folder.folder_uid, folder));
+    folders.forEach((folder) => folderMap.set(folder.uid, folder));
 
     const result = folders.map((folder) => {
       const pathParts: string[] = [folder.name];
-      let currentParentUid = folder?.details?.split(", Parent:")[1]?.trim();
+      let currentParentUid = parseParentUidFromDetails(folder.details);
 
-      while (currentParentUid !== '/') {
+      while (currentParentUid && currentParentUid !== '/') {
         const parent = folderMap.get(currentParentUid);
         if (!parent) {
           break;
         }
         pathParts.unshift(parent.name);
-        currentParentUid = parent.parent_uid;
+        currentParentUid = parseParentUidFromDetails(parent.details);
       }
 
       pathParts.unshift('My Vault');
 
       return {
-        folderUid: folder['uid'],
-        name: folder['name'],
-        parentUid: folder['parent_uid'],
+        folderUid: folder.uid,
+        name: folder.name,
+        parentUid: parseParentUidFromDetails(folder.details) ?? '/',
         folderPath: pathParts.join(' / '),
+        source: folder.source,
       };
     });
 

--- a/src/commands/storage/cliStorageManager.ts
+++ b/src/commands/storage/cliStorageManager.ts
@@ -8,7 +8,6 @@ import {
 } from '../../types';
 import { logger } from '../../utils/logger';
 import { CliService } from '../../services/cli';
-import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER } from '../../utils/constants';
 
 function parseParentUidFromDetails(details?: string): string | undefined {
   if (!details?.includes(', Parent:')) {
@@ -105,18 +104,18 @@ export class CliStorageManager extends BaseStorageManager {
       name: 'My Vault',
       parentUid: '/',
       folderPath: '/',
-      source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+      source: "",
     };
 
     const updatedParsedFolder = parsedFolder.map((folder) => {
       // in below return we dont care about parentUid, folderPath, source because we are only using folderUid to check if the folder is valid or not
-      // So those fields are set to empty string and CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER
+      // So those fields are set to empty string
       return {
-        folderUid : folder.shared_folder_uid ? folder.shared_folder_uid : folder.folder_uid,
+        folderUid : folder.folder_uid,
         name: folder.name,
         parentUid: "",
         folderPath: '',
-        source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+        source: "",
       };
     });
 

--- a/src/commands/storage/cliStorageManager.ts
+++ b/src/commands/storage/cliStorageManager.ts
@@ -61,7 +61,7 @@ export class CliStorageManager extends BaseStorageManager {
       name: 'My Vault',
       parentUid: '/',
       folderPath: '/',
-      source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+      source: "",
     };
 
     const foldersWithPaths = [

--- a/src/commands/storage/ksmStorageManager.ts
+++ b/src/commands/storage/ksmStorageManager.ts
@@ -65,6 +65,7 @@ export class KsmStorageManager extends BaseStorageManager {
         name: folder.name,
         parentUid: folder.parentUid || '/',
         folderPath: pathParts.join(' / '),
+        source: "", // TODO: add source , currenlty we are not fetting KD-Folder's from KSM
       };
     });
 

--- a/src/commands/utils/cliRecordCommandResolver.ts
+++ b/src/commands/utils/cliRecordCommandResolver.ts
@@ -1,0 +1,62 @@
+import { window } from 'vscode';
+import { IFolder } from '../../types';
+import { commonQuickPickOptions } from '../../utils/helper';
+import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER } from '../../utils/constants';
+import { CLI_INFO_MESSAGES } from '../../utils/cli-messages';
+
+export const RECORD_ADD_COMMANDS = {
+  CLASSIC: 'record-add',
+  NESTED_SHARE_FOLDER: 'nsf-record-add',
+} as const;
+
+export type RecordAddCommand =
+  (typeof RECORD_ADD_COMMANDS)[keyof typeof RECORD_ADD_COMMANDS];
+
+/**
+ * Resolves which `record-add` command variant to use based on the current storage.
+ *
+ * - "My Vault" (root folder) — prompts the user to choose between the classic
+ *   and the new (nested share folder) permission model.
+ * - Nested share folder — `nsf-record-add` (no prompt).
+ * - Any other folder — `record-add` (no prompt).
+ *
+ * Returns `undefined` only when the user dismisses the permission model quick pick.
+ */
+export async function resolveRecordAddCommand(
+  currentStorage: IFolder | null
+): Promise<RecordAddCommand | undefined> {
+  if (currentStorage?.folderUid === '/') {
+    return await promptForPermissionModel();
+  }
+
+  if (currentStorage?.source === CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER) {
+    return RECORD_ADD_COMMANDS.NESTED_SHARE_FOLDER;
+  }
+
+  return RECORD_ADD_COMMANDS.CLASSIC;
+}
+
+async function promptForPermissionModel(): Promise<
+  RecordAddCommand | undefined
+> {
+  const selection = await window.showQuickPick(
+    [
+      {
+        label: 'Use classic permission model',
+        value: RECORD_ADD_COMMANDS.CLASSIC,
+      },
+      {
+        label: 'Use new permission model',
+        value: RECORD_ADD_COMMANDS.NESTED_SHARE_FOLDER,
+      },
+    ],
+    {
+      title: CLI_INFO_MESSAGES.QUICK_PICK_FOR_PERMISSION_MODEL_TITLE,
+      placeHolder:
+        CLI_INFO_MESSAGES.QUICK_PICK_FOR_PERMISSION_MODEL_PLACEHOLDER,
+      ...commonQuickPickOptions,
+    }
+  );
+
+  return selection?.value;
+}

--- a/src/services/cli.ts
+++ b/src/services/cli.ts
@@ -1,9 +1,15 @@
 import { env, ExtensionContext, Uri, window } from 'vscode';
 import { logger } from '../utils/logger';
-import { promisifyExec, StatusBarSpinner } from '../utils/helper';
+import {
+  hasKeeperNotationControlCharacters,
+  isValidKeeperRecordUid,
+  promisifyExec,
+  StatusBarSpinner,
+} from '../utils/helper';
 import { exec, spawn, ChildProcess } from 'child_process';
 import { KEEPER_COMMANDER_DOCS_URLS } from '../utils/constants';
 import { HELPER_MESSAGES } from '../utils/constants';
+import { CLI_ERROR_MESSAGES } from '../utils/cli-messages';
 
 // Patterns to filter out from Keeper Commander output (not real errors)
 const BENIGN_PATTERNS = [
@@ -233,12 +239,19 @@ export class CliService {
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutId = setTimeout(
           () => reject(new Error('Must be asking for interactive login')),
-          30 * 1000 // 30 seconds timeout for auth check
+          5 * 60 * 1000 // 5 minutes timeout for auth check
         );
       });
 
       // Create execution promise for the actual auth check
-      const execPromise = this.executeCommanderCommandLegacyRaw('this-device');
+      /**
+       * We have updated below command to use 'login-status' command instead of 'this-device' command bec 'this-device' takes long time based upon the data in vault.
+       * 'login-status' command returns "Logged in" or "Not logged in" based upon if persistent login is on or off which is much faster to execute.
+       * 
+       */
+
+      // const execPromise = this.executeCommanderCommandLegacyRaw('this-device');
+      const execPromise = this.executeCommanderCommandLegacyRaw('login-status'); // this returns "Logged in" or "Not logged in" based upon if persistent login is on or off
 
       // Race between execution and timeout to prevent hanging
       const { stdout, stderr } = await Promise.race([
@@ -252,10 +265,12 @@ export class CliService {
       }
 
       const out = `${stdout}\n${stderr}`;
-      const persistentOn = /Persistent Login:\s*ON/i.test(out);
+      // const persistentOn = /Persistent Login:\s*ON/i.test(out);
+      const isUserLoggedIn = /Logged in/i.test(out); // this returns true if user is logged in, false otherwise
+
 
       // If persistent login is on, we're authenticated
-      if (persistentOn) {
+      if (isUserLoggedIn) {
         logger.logInfo(`Keeper Commander CLI Authenticated: YES (Persistent)`);
         return true;
       }
@@ -357,10 +372,24 @@ export class CliService {
     }
   }
 
+  private assertSafeCommanderArgs(command: string, args: string[]): void {
+    for (const arg of args) {
+      if (hasKeeperNotationControlCharacters(arg)) {
+        throw new Error(CLI_ERROR_MESSAGES.INVALID_COMMANDER_ARGUMENT);
+      }
+    }
+
+    if (command === 'get' && args.length > 0 && !isValidKeeperRecordUid(args[0])) {
+      throw new Error(CLI_ERROR_MESSAGES.INVALID_COMMANDER_RECORD_UID);
+    }
+  }
+
   public async executeCommanderCommand(
     command: string,
     args: string[] = []
   ): Promise<string> {
+    this.assertSafeCommanderArgs(command, args);
+
     // Initialize on first use
     if (!this.isInitialized) {
       await this.lazyInitialize();

--- a/src/services/cli.ts
+++ b/src/services/cli.ts
@@ -265,8 +265,10 @@ export class CliService {
       }
 
       const out = `${stdout}\n${stderr}`;
+      
       // const persistentOn = /Persistent Login:\s*ON/i.test(out);
-      const isUserLoggedIn = /Logged in/i.test(out); // this returns true if user is logged in, false otherwise
+      const isUserLoggedIn =
+        /Not logged in/i.test(out) ? false : /Logged in/i.test(out);
 
 
       // If persistent login is on, we're authenticated

--- a/src/services/cli.ts
+++ b/src/services/cli.ts
@@ -6,7 +6,7 @@ import {
   promisifyExec,
   StatusBarSpinner,
 } from '../utils/helper';
-import { exec, spawn, ChildProcess } from 'child_process';
+import { execFile, spawn, ChildProcess } from 'child_process';
 import { KEEPER_COMMANDER_DOCS_URLS } from '../utils/constants';
 import { HELPER_MESSAGES } from '../utils/constants';
 import { CLI_ERROR_MESSAGES } from '../utils/cli-messages';
@@ -317,7 +317,9 @@ export class CliService {
         );
       });
 
-      const execPromise = this.executeCommanderCommandLegacyRaw('biometric verify');
+      const execPromise = this.executeCommanderCommandLegacyRaw('biometric', [
+        'verify',
+      ]);
 
       const { stdout, stderr } = await Promise.race([
         execPromise,
@@ -340,13 +342,39 @@ export class CliService {
     }
   }
 
-  // add a raw executor (no cleaning)
+  /**
+   * Raw executor for the Keeper Commander CLI (no output cleaning).
+   *
+   * Spawns `keeper` directly via `execFile` with a pre-tokenized argv. No
+   * shell is involved, so shell metacharacters in `command` or `args`
+   * (`;`, `&&`, `|`, `$`, backticks, redirections, globs, ...) are passed
+   * to the child as plain bytes and cannot be interpreted as syntax. This
+   * is the structural defense behind `assertSafeCommanderArgs` — the regex
+   * is the policy, this is the mechanism.
+   *
+   * On Windows the `keeper` entry point may be a `.cmd` shim that Node's
+   * `execFile` does not always resolve, so we route through `cmd /c` (the
+   * same pattern the persistent-process path already uses). Args are still
+   * passed as a tokenized array; cmd.exe receives them as separate argv
+   * entries, not concatenated into a string.
+   *
+   * `command` must be a single argv token (e.g. `"get"`, `"login-status"`).
+   * Multi-word subcommands such as `biometric verify` must be passed as
+   * `("biometric", ["verify"])`.
+   */
   private async executeCommanderCommandLegacyRaw(
     command: string,
     args: string[] = []
   ): Promise<{ stdout: string; stderr: string }> {
-    const fullCommand = `keeper ${command} ${args.join(' ')}`;
-    const { stdout, stderr } = await promisifyExec(exec)(fullCommand);
+    const isWindows = process.platform === 'win32';
+    const file = isWindows ? 'cmd' : 'keeper';
+    const argv = isWindows
+      ? ['/c', 'keeper', command, ...args]
+      : [command, ...args];
+
+    const { stdout, stderr } = await promisifyExec(execFile)(file, argv, {
+      maxBuffer: 10 * 1024 * 1024,
+    });
     return { stdout: String(stdout || ''), stderr: String(stderr || '') };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,18 +1,11 @@
 import { KEEPER_NOTATION_FIELD_TYPES } from '../utils/constants';
 
-export interface IVaultFolder {
-  folder_uid: string;
-  name: string;
-  parent_uid: string;
-  flags?: string;
-  folder_path?: string;
-}
-
 export interface IFolder {
   folderUid: string;
   name: string;
   parentUid: string;
   folderPath?: string;
+  source: string;
 }
 
 export interface ICliListFolderResponse {
@@ -55,6 +48,7 @@ export interface ICliListFolderResponse {
   parent_uid: string;
   flags?: string;
   details: string;
+  source: string;
 }
 
 export enum ModeType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,9 +38,12 @@ export interface IField {
 export interface ICliListRecordResponse {
   record_uid: string;
   title: string;
-  type: string;
-  shared: string;
   record_category: string;
+}
+
+export interface ICliNsfListRecordResponse {
+  UID: string;
+  Title: string;
 }
 
 export interface ICliListFolderResponse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,20 +35,30 @@ export interface IField {
   fieldType?: KEEPER_NOTATION_FIELD_TYPES;
 }
 
-export interface ICliListCommandResponse {
+export interface ICliListRecordResponse {
   record_uid: string;
   title: string;
   type: string;
   shared: string;
+  record_category: string;
 }
 
 export interface ICliListFolderResponse {
   uid: string;
   name: string;
-  parent_uid: string;
-  flags?: string;
+  // parent_uid: string; // this currenlty not used
+  // flags?: string; // this currenlty not used
   details: string;
   source: string;
+}
+
+export interface ICliGetFolderResponse {
+  folder_uid: string; // this attribute for KD-Folder's and classic non shared folder
+  shared_folder_uid?: string; // this is required for shared folders response
+
+  type?: string;
+  name: string;
+  parent_folder_uid?: string;
 }
 
 export enum ModeType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,19 +49,15 @@ export interface ICliNsfListRecordResponse {
 export interface ICliListFolderResponse {
   uid: string;
   name: string;
-  // parent_uid: string; // this currenlty not used
-  // flags?: string; // this currenlty not used
   details: string;
   source: string;
 }
 
 export interface ICliGetFolderResponse {
-  folder_uid: string; // this attribute for KD-Folder's and classic non shared folder
-  shared_folder_uid?: string; // this is required for shared folders response
-
+  folder_uid: string;
   type?: string;
   name: string;
-  parent_folder_uid?: string;
+  parent_uid?: string;
 }
 
 export enum ModeType {

--- a/src/utils/cli-messages.ts
+++ b/src/utils/cli-messages.ts
@@ -21,6 +21,9 @@ export const CLI_ERROR_MESSAGES = {
   FAILED_TO_CHOOSE_FOLDER: 'Failed to choose folder',
   FAILED_TO_SAVE_SECRET: 'Failed to save secret',
   FAILED_TO_SWITCH_TO_KSM: 'Failed to switch to KSM mode',
+  INVALID_COMMANDER_ARGUMENT:
+    'Invalid Keeper Commander argument: control characters are not allowed.',
+  INVALID_COMMANDER_RECORD_UID: 'Invalid Keeper record UID.',
 } as const;
 
 export const CLI_LOGGER_DEBUG_MESSAGES = {

--- a/src/utils/cli-messages.ts
+++ b/src/utils/cli-messages.ts
@@ -6,6 +6,8 @@ export const CLI_INFO_MESSAGES = {
   RETRIEVING_SECRET_DETAILS: 'Retrieving secret details...',
   NO_RECORD_DATA_FOUND_FOR_RECORD_UID: 'No record data found for record UID',
   NO_FIELDS_TO_SHOW: 'No renderable fields. Field list is empty or only contains object-type values that were excluded from display.',
+  QUICK_PICK_FOR_PERMISSION_MODEL_TITLE: 'Select permission model',
+  QUICK_PICK_FOR_PERMISSION_MODEL_PLACEHOLDER: 'Choose how the new record should be created in My Vault',
 } as const;
 
 export const CLI_SUCCESS_MESSAGES = {
@@ -33,6 +35,7 @@ export const CLI_LOGGER_DEBUG_MESSAGES = {
   NO_RECORDS_FOUND: 'No records found',
   NO_RECORD_DATA_FOUND_FOR_RECORD_UID: 'No record data found for record UID',
   USER_CANCELLED_RECORD_NAME_INPUT: 'User cancelled while entering record name',
+  USER_CANCELLED_PERMISSION_MODEL_SELECTION: 'User cancelled while selecting permission model',
   ENSURING_VALID_STORAGE: 'Ensuring valid storage',
   SYNCING_DOWN_LATEST_RECORDS_FROM_VAULT: 'Syncing down latest records from vault',
   EXECUTING_LIST_COMMAND_TO_GET_AVAILABLE_RECORDS: 'Executing list command to get available records',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -16,11 +16,21 @@ export const COMMANDS = {
   SWITCH_TO_KSM: makeCommand('switchToKsm'),
 };
 
+/** Keeper record UIDs are URL-safe base64 tokens (no slashes, whitespace, or control chars). */
+export const KEEPER_RECORD_UID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+const KEEPER_NOTATION_RECORD_UID = '([A-Za-z0-9_-]+)';
+
 export const KEEPER_NOTATION_PATTERNS = {
-  BASIC: /^keeper:\/\/([^\/]+)\/(type|title|notes)$/,
-  FILE: /^keeper:\/\/([^\/]+)\/file\/([^\/\[\]]+)$/,
-  FIELD:
-    /^keeper:\/\/([^\/]+)\/(field|custom_field)\/([^\/\[\]]+)(?:\[([^\]]*)\])?(?:\[([^\]]*)\])?$/,
+  BASIC: new RegExp(
+    `^keeper://${KEEPER_NOTATION_RECORD_UID}/(type|title|notes)$`
+  ),
+  FILE: new RegExp(
+    `^keeper://${KEEPER_NOTATION_RECORD_UID}/file/([^\\/\\[\\]]+)$`
+  ),
+  FIELD: new RegExp(
+    `^keeper://${KEEPER_NOTATION_RECORD_UID}/(field|custom_field)/([^\\/\\[\\]]+)(?:\\[([^\\]]*)\\])?(?:\\[([^\\]]*)\\])?$`
+  ),
 };
 
 export const KEEPER_COMMANDER_DOCS_URLS = {
@@ -270,6 +280,9 @@ export const BASE_HANDLER_MESSAGES = {
     SELECTED_FILE_IS_NOT_AN_ENVIRONMENT_FILE:
       'Selected file is not an environment file. Must be a .env or .env.* file',
     FAILED_TO_PARSE_KEEPER_REFERENCE: 'Failed to parse keeper:// reference',
+    INVALID_KEEPER_REFERENCE_IN_ENV:
+      'Invalid Keeper reference in .env — contains line break or control character.',
+    INVALID_KEEPER_RECORD_UID: 'Invalid Keeper record UID.',
   },
   DEBUG: {},
   INPUT: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -16,10 +16,10 @@ export const COMMANDS = {
   SWITCH_TO_KSM: makeCommand('switchToKsm'),
 };
 
-/** Keeper record UIDs are URL-safe base64 tokens (no slashes, whitespace, or control chars). */
-export const KEEPER_RECORD_UID_PATTERN = /^[A-Za-z0-9_-]+$/;
+/** Keeper record UIDs are URL-safe base64 tokens of exactly 22 characters (no slashes, whitespace, or control chars). */
+export const KEEPER_RECORD_UID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
 
-const KEEPER_NOTATION_RECORD_UID = '([A-Za-z0-9_-]+)';
+const KEEPER_NOTATION_RECORD_UID = '([A-Za-z0-9_-]{22})';
 
 export const KEEPER_NOTATION_PATTERNS = {
   BASIC: new RegExp(
@@ -318,7 +318,7 @@ export const BASE_HANDLER_MESSAGES = {
 
 export const PREVIOUS_USER_SELECTED_MODE_KEY = 'previousUserSelectedMode';
 
-export const CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER = 'Nested Share Folder';
-export const CLI_FOLDER_SOURCE_LEGACY = 'Legacy';
-export const CLI_RECORD_CATEGORY_NESTED = 'Nested';
-export const CLI_RECORD_CATEGORY_CLASSIC = 'Classic';
+export const CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER = 'nested_share_folder';
+export const CLI_FOLDER_SOURCE_LEGACY = 'classic_folder';
+export const CLI_RECORD_CATEGORY_NESTED = 'nested';
+export const CLI_RECORD_CATEGORY_CLASSIC = 'classic';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -318,5 +318,7 @@ export const BASE_HANDLER_MESSAGES = {
 
 export const PREVIOUS_USER_SELECTED_MODE_KEY = 'previousUserSelectedMode';
 
-export const CLI_SOURCE_KEEPER_DRIVE = 'KeeperDrive';
-export const CLI_SOURCE_LEGACY = 'Legacy';
+export const CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER = 'Nested Share Folder';
+export const CLI_FOLDER_SOURCE_LEGACY = 'Legacy';
+export const CLI_RECORD_CATEGORY_NESTED = 'Nested';
+export const CLI_RECORD_CATEGORY_CLASSIC = 'Classic';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -304,3 +304,6 @@ export const BASE_HANDLER_MESSAGES = {
 } as const;
 
 export const PREVIOUS_USER_SELECTED_MODE_KEY = 'previousUserSelectedMode';
+
+export const CLI_SOURCE_KEEPER_DRIVE = 'KeeperDrive';
+export const CLI_SOURCE_LEGACY = 'Legacy';

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { IFolder, IVaultFolder, Mode } from '../types';
+import { Mode } from '../types';
 import {
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_NOTATION_PATTERNS,
@@ -159,39 +159,6 @@ export class StatusBarSpinner {
     this.hide();
     this.statusBarItem.dispose();
   }
-}
-
-export function resolveFolderPaths(folders: IVaultFolder[]): IFolder[] {
-  logger.logDebug(`Resolving paths for ${folders.length} folders`);
-  // Map folderUid to folder for quick lookup
-  const folderMap = new Map<string, IVaultFolder>();
-  folders.forEach((folder) => folderMap.set(folder.folder_uid, folder));
-
-  const result = folders.map((folder) => {
-    const pathParts: string[] = [folder.name];
-    let currentParentUid = folder.parent_uid;
-
-    while (currentParentUid !== '/') {
-      const parent = folderMap.get(currentParentUid);
-      if (!parent) {
-        break;
-      }
-      pathParts.unshift(parent.name);
-      currentParentUid = parent.parent_uid;
-    }
-
-    pathParts.unshift('My Vault');
-
-    return {
-      folderUid: folder['folder_uid'],
-      name: folder['name'],
-      parentUid: folder['parent_uid'],
-      folderPath: pathParts.join(' / '),
-    };
-  });
-
-  logger.logDebug(`Resolved paths for ${result.length} folders`);
-  return result;
 }
 
 export const documentMatcher =

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Mode } from '../types';
 import {
+  BASE_HANDLER_MESSAGES,
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_NOTATION_PATTERNS,
+  KEEPER_RECORD_UID_PATTERN,
 } from './constants';
 import { logger } from './logger';
 import {
@@ -12,8 +14,36 @@ import {
   window,
 } from 'vscode';
 
+/** Matches ASCII control characters including \\r, \\n, \\0, and \\t. */
+const KEEPER_NOTATION_CONTROL_CHAR_PATTERN = /[\x00-\x1F\x7F]/;
+
+export function hasKeeperNotationControlCharacters(value: string): boolean {
+  return KEEPER_NOTATION_CONTROL_CHAR_PATTERN.test(value);
+}
+
+export function isValidKeeperRecordUid(recordUid: string): boolean {
+  return KEEPER_RECORD_UID_PATTERN.test(recordUid);
+}
+
+export function assertSafeKeeperNotationEnvValue(
+  value: string,
+  envKey: string
+): void {
+  if (hasKeeperNotationControlCharacters(value)) {
+    const message =
+      BASE_HANDLER_MESSAGES.ERROR.INVALID_KEEPER_REFERENCE_IN_ENV +
+      ` (${envKey})`;
+    logger.logError(message);
+    throw new Error(message);
+  }
+}
+
 export function validateKeeperReference(reference: string): boolean {
   logger.logDebug(`Validating keeper reference: ${reference}`);
+  if (hasKeeperNotationControlCharacters(reference)) {
+    logger.logDebug('Keeper reference validation result: false (control char)');
+    return false;
+  }
   const isValid = KEEPER_NOTATION_PATTERNS.FIELD.test(reference);
   logger.logDebug(`Keeper reference validation result: ${isValid}`);
   return isValid;
@@ -30,6 +60,10 @@ export function createKeeperReference(
 
   if (!recordUid) {
     logger.logError('recordUid is required to create a keeper reference');
+    return null;
+  }
+  if (!isValidKeeperRecordUid(recordUid)) {
+    logger.logError('recordUid contains invalid characters');
     return null;
   }
   if (!itemName) {
@@ -65,21 +99,29 @@ export function parseKeeperReference(reference: string): {
 } | null {
   logger.logDebug(`Parsing keeper reference: ${reference}`);
 
-  // Check if the reference is vaild keeper notation
   if (!validateKeeperReference(reference)) {
     logger.logError(`Invalid keeper notation reference: ${reference}`);
     return null;
   }
 
-  // Parse the reference
-  const removedKeeperPrefix = reference.replace('keeper://', '');
-  const [recordUid, fieldType, itemName] = removedKeeperPrefix.split('/');
+  const match = KEEPER_NOTATION_PATTERNS.FIELD.exec(reference);
+  if (!match) {
+    logger.logError(`Invalid keeper notation reference: ${reference}`);
+    return null;
+  }
 
-  const result = {
-    recordUid,
-    fieldType: fieldType as KEEPER_NOTATION_FIELD_TYPES,
-    itemName,
-  };
+  const recordUid = match[1];
+  const fieldType = match[2] as KEEPER_NOTATION_FIELD_TYPES;
+  const itemName = match[3];
+
+  if (!isValidKeeperRecordUid(recordUid)) {
+    logger.logError(
+      `Invalid keeper record UID in reference: ${reference}`
+    );
+    return null;
+  }
+
+  const result = { recordUid, fieldType, itemName };
   logger.logDebug(`Parsed keeper reference:`, result);
   return result;
 }

--- a/test/unit/commands/factories/handlerFactory.test.ts
+++ b/test/unit/commands/factories/handlerFactory.test.ts
@@ -125,7 +125,11 @@ describe('HandlerFactory', () => {
       );
 
       // Verify CliGetValueHandler was created
-      expect(CliGetValueHandler).toHaveBeenCalledWith(mockSpinner, mockCliService);
+      expect(CliGetValueHandler).toHaveBeenCalledWith(
+        mockSpinner,
+        mockCliService,
+        mockCliStorageManager
+      );
 
       // Verify CliGeneratePasswordHandler was created
       expect(CliGeneratePasswordHandler).toHaveBeenCalledWith(

--- a/test/unit/commands/handlers/base/baseGetValueHandler.test.ts
+++ b/test/unit/commands/handlers/base/baseGetValueHandler.test.ts
@@ -58,7 +58,9 @@ describe('BaseGetValueHandler', () => {
 
       expect(window.showQuickPick).toHaveBeenCalledWith(items, {
         ...commonQuickPickOptions,
-        title: BASE_HANDLER_MESSAGES.INPUT.QUICK_PICK_FOR_RECORDS_TITLE,
+        title:
+          BASE_HANDLER_MESSAGES.INPUT.QUICK_PICK_FOR_RECORDS_TITLE +
+          ' (Showing compatible records)',
         placeHolder: BASE_HANDLER_MESSAGES.INPUT.QUICK_PICK_FOR_RECORDS_PLACEHOLDER,
       });
       expect(result).toEqual(selectedItem);

--- a/test/unit/commands/handlers/base/baseRunSecurelyHandler.test.ts
+++ b/test/unit/commands/handlers/base/baseRunSecurelyHandler.test.ts
@@ -31,6 +31,7 @@ jest.mock('vscode', () => ({
     showInputBox: jest.fn(),
     showOpenDialog: jest.fn(),
     showInformationMessage: jest.fn(),
+    showErrorMessage: jest.fn(),
     activeTextEditor: undefined,
     createTerminal: jest.fn(),
     createOutputChannel: jest.fn(() => ({
@@ -353,6 +354,26 @@ describe('BaseRunSecurelyHandler', () => {
       await (handler as any).resolveSecrets('/workspace/.env', mockFetchSecret);
 
       expect(logger.logError).toHaveBeenCalled();
+      expect(mockFetchSecret).not.toHaveBeenCalled();
+    });
+
+    it('should reject keeper references with control characters in .env', async () => {
+      const maliciousValue = 'keeper://abc\nksm.bat\n/field/password';
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        `API_PASSWORD="${maliciousValue}"`
+      );
+      (dotenv.parse as jest.Mock).mockReturnValue({
+        API_PASSWORD: maliciousValue,
+      });
+      const mockFetchSecret = jest.fn();
+
+      await expect(
+        (handler as any).resolveSecrets('/workspace/.env', mockFetchSecret)
+      ).rejects.toThrow(/control character/i);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        BASE_HANDLER_MESSAGES.ERROR.INVALID_KEEPER_REFERENCE_IN_ENV
+      );
       expect(mockFetchSecret).not.toHaveBeenCalled();
     });
 

--- a/test/unit/commands/handlers/cli/cliGeneratePasswordHandler.test.ts
+++ b/test/unit/commands/handlers/cli/cliGeneratePasswordHandler.test.ts
@@ -28,6 +28,7 @@ jest.mock('vscode', () => ({
   ...jest.requireActual('vscode'),
   window: {
     showInputBox: jest.fn(),
+    showQuickPick: jest.fn(),
     showInformationMessage: jest.fn(),
     showErrorMessage: jest.fn(),
     activeTextEditor: null,
@@ -91,6 +92,15 @@ describe('CliGeneratePasswordHandler', () => {
 
     // Reset mocks
     (createKeeperReference as jest.Mock).mockReset();
+
+    // Default permission-model selection for My Vault scenarios.
+    // resolveRecordAddCommand prompts via showQuickPick when storage is the root
+    // folder; default to the classic option so existing tests keep using
+    // the `record-add` command.
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: 'Use classic permission model',
+      value: 'record-add',
+    });
   });
 
   describe('constructor', () => {

--- a/test/unit/commands/handlers/cli/cliGetValueHandler.test.ts
+++ b/test/unit/commands/handlers/cli/cliGetValueHandler.test.ts
@@ -128,7 +128,7 @@ describe('CliGetValueHandler', () => {
 
       expect(mockCliService.isCLIReady).toHaveBeenCalled();
       expect(mockSpinner.show).toHaveBeenCalledWith(CLI_INFO_MESSAGES.RETRIEVING_SECRETS);
-      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('sync-down');
+      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('sync-down --force');
       expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('list', ['--format=json']);
       expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('get', ['record1', '--format=json']);
       expect(logger.logDebug).toHaveBeenCalledWith(

--- a/test/unit/commands/handlers/cli/cliGetValueHandler.test.ts
+++ b/test/unit/commands/handlers/cli/cliGetValueHandler.test.ts
@@ -1,6 +1,7 @@
 import { window } from 'vscode';
 import { CliGetValueHandler } from '../../../../../src/commands/handlers/cli/cliGetValueHandler';
 import { CliService } from '../../../../../src/services/cli';
+import { CliStorageManager } from '../../../../../src/commands/storage/cliStorageManager';
 import { StatusBarSpinner } from '../../../../../src/utils/helper';
 import { logger } from '../../../../../src/utils/logger';
 import {
@@ -10,12 +11,17 @@ import {
   CLI_LOGGER_ERROR_MESSAGES,
   CLI_SUCCESS_MESSAGES,
 } from '../../../../../src/utils/cli-messages';
-import { KEEPER_NOTATION_FIELD_TYPES } from '../../../../../src/utils/constants';
-import { ICliListCommandResponse } from '../../../../../src/types';
+import {
+  CLI_FOLDER_SOURCE_LEGACY,
+  CLI_RECORD_CATEGORY_CLASSIC,
+  KEEPER_NOTATION_FIELD_TYPES,
+} from '../../../../../src/utils/constants';
+import { ICliListRecordResponse } from '../../../../../src/types';
 import { IRecordQuickPick } from '../../../../../src/types/ksm';
 
 // Mock dependencies
 jest.mock('../../../../../src/services/cli');
+jest.mock('../../../../../src/commands/storage/cliStorageManager');
 jest.mock('../../../../../src/utils/logger');
 jest.mock('../../../../../src/utils/helper', () => ({
   ...jest.requireActual('../../../../../src/utils/helper'),
@@ -47,8 +53,19 @@ const { createKeeperReference, safeJsonParse } = require('../../../../../src/uti
 describe('CliGetValueHandler', () => {
   let mockCliService: jest.Mocked<CliService>;
   let mockSpinner: jest.Mocked<StatusBarSpinner>;
+  let mockStorageManager: jest.Mocked<CliStorageManager>;
   let cliGetValueHandler: CliGetValueHandler;
   let mockActiveTextEditor: any;
+
+  // Default current storage used by most tests: a Legacy (classic) folder so the
+  // handler routes to the `list --format=json` command path.
+  const legacyFolderStorage = {
+    folderUid: 'folder123',
+    name: 'Classic Folder',
+    parentUid: '/',
+    folderPath: '/Classic Folder',
+    source: CLI_FOLDER_SOURCE_LEGACY,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -65,6 +82,10 @@ describe('CliGetValueHandler', () => {
       updateMessage: jest.fn(),
     } as unknown as jest.Mocked<StatusBarSpinner>;
 
+    mockStorageManager = {
+      getCurrentStorage: jest.fn().mockReturnValue(legacyFolderStorage),
+    } as unknown as jest.Mocked<CliStorageManager>;
+
     mockActiveTextEditor = {
       document: {
         uri: { fsPath: '/test/file.txt' },
@@ -76,7 +97,11 @@ describe('CliGetValueHandler', () => {
       edit: jest.fn().mockResolvedValue(true),
     };
 
-    cliGetValueHandler = new CliGetValueHandler(mockSpinner, mockCliService);
+    cliGetValueHandler = new CliGetValueHandler(
+      mockSpinner,
+      mockCliService,
+      mockStorageManager
+    );
 
     // Reset mocks
     (createKeeperReference as jest.Mock).mockReset();
@@ -84,18 +109,22 @@ describe('CliGetValueHandler', () => {
   });
 
   describe('constructor', () => {
-    it('should initialize with spinner and cliService', () => {
+    it('should initialize with spinner, cliService and storageManager', () => {
       expect(cliGetValueHandler).toBeInstanceOf(CliGetValueHandler);
-      const handler = new CliGetValueHandler(mockSpinner, mockCliService);
+      const handler = new CliGetValueHandler(
+        mockSpinner,
+        mockCliService,
+        mockStorageManager
+      );
       expect(handler).toBeDefined();
     });
   });
 
   describe('execute', () => {
     it('should execute successfully with records and fields', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
-        { record_uid: 'record2', title: 'Record 2', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
+        { record_uid: 'record2', title: 'Record 2', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: [
@@ -179,8 +208,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should return early when user cancels record selection', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
 
       mockCliService.isCLIReady.mockResolvedValue(true);
@@ -199,8 +228,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should show no record data message when record data is empty', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const selectedRecord: IRecordQuickPick = { label: 'Record 1', value: 'record1' };
 
@@ -226,8 +255,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should show no fields message when no fields available', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = { fields: [], custom: [] };
       const selectedRecord: IRecordQuickPick = { label: 'Record 1', value: 'record1' };
@@ -251,8 +280,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should return early when user cancels field selection', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: [{ type: 'login', label: 'Username', value: ['user1'] }],
@@ -281,8 +310,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should throw error when createKeeperReference returns null', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: [{ type: 'login', label: 'Username', value: ['user1'] }],
@@ -318,8 +347,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should not show success message when insert fails', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: [{ type: 'login', label: 'Username', value: ['user1'] }],
@@ -389,8 +418,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should process both fields and custom fields', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: [
@@ -432,8 +461,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should trim record value before creating keeper reference', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: [{ type: 'login', label: 'Username', value: ['user1'] }],
@@ -467,8 +496,8 @@ describe('CliGetValueHandler', () => {
     });
 
     it('should handle null/undefined fields and custom arrays', async () => {
-      const mockRecords: ICliListCommandResponse[] = [
-        { record_uid: 'record1', title: 'Record 1', type: 'record', shared: 'false' },
+      const mockRecords: ICliListRecordResponse[] = [
+        { record_uid: 'record1', title: 'Record 1', record_category: CLI_RECORD_CATEGORY_CLASSIC },
       ];
       const mockRecordData = {
         fields: null,

--- a/test/unit/commands/handlers/cli/cliSaveValueHandler.test.ts
+++ b/test/unit/commands/handlers/cli/cliSaveValueHandler.test.ts
@@ -20,6 +20,7 @@ jest.mock('vscode', () => ({
   ...jest.requireActual('vscode'),
   window: {
     showInputBox: jest.fn(),
+    showQuickPick: jest.fn(),
     showInformationMessage: jest.fn(),
     showErrorMessage: jest.fn(),
     showTextDocument: jest.fn(),
@@ -74,6 +75,15 @@ describe('CliSaveValueHandler', () => {
     } as unknown as jest.Mocked<CliStorageManager>;
 
     handler = new CliSaveValueHandler(mockSpinner, mockCliService, mockStorageManager);
+
+    // Default permission-model selection for My Vault scenarios.
+    // resolveRecordAddCommand prompts via showQuickPick when storage is the root
+    // folder; default to the classic option so existing tests keep using
+    // the `record-add` command.
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: 'Use classic permission model',
+      value: 'record-add',
+    });
   });
 
   const spyGetSelectedText = () => jest.spyOn(BaseSaveValueHandler.prototype as any, 'getSelectedText');

--- a/test/unit/commands/storage/baseStorageManager.test.ts
+++ b/test/unit/commands/storage/baseStorageManager.test.ts
@@ -221,6 +221,31 @@ describe('BaseStorageManager', () => {
         'TestStorageManager: Folder no longer exists on Keeper vault with value: Test Folder'
       );
     });
+
+    it('should use getFolderByUid when provided instead of fetching all folders', async () => {
+      const mockStorage: IFolder = {
+        folderUid: '123',
+        name: 'Test Folder',
+        parentUid: 'root-folder',
+        folderPath: '/Test Folder',
+      };
+      (mockContext.workspaceState.get as jest.Mock).mockReturnValue(mockStorage);
+
+      const mockFetchAvailableFolders = jest.fn();
+      const mockGetFolderByUid = jest.fn().mockResolvedValue({
+        availableFolders: [mockStorage],
+        rootFolder: { folderUid: '/', name: 'My Vault', parentUid: '/', folderPath: '/' },
+      });
+
+      const result = await (storageManager as any).validateCurrentStorage(
+        mockFetchAvailableFolders,
+        mockGetFolderByUid
+      );
+
+      expect(result).toBe(true);
+      expect(mockGetFolderByUid).toHaveBeenCalledWith('123');
+      expect(mockFetchAvailableFolders).not.toHaveBeenCalled();
+    });
   });
 
   describe('ensureValidStorage', () => {
@@ -419,9 +444,9 @@ describe('BaseStorageManager', () => {
 
       expect(window.showQuickPick).toHaveBeenCalledWith(
         expect.arrayContaining([
-          expect.objectContaining({ label: 'My Vault', value: '/' }),
-          expect.objectContaining({ label: 'Folder 1', value: '123' }),
-          expect.objectContaining({ label: 'Folder 2', value: '456' }),
+          expect.objectContaining({ label: 'My Vault ', value: '/' }),
+          expect.objectContaining({ label: 'Folder 1 ', value: '123' }),
+          expect.objectContaining({ label: 'Folder 2 ', value: '456' }),
         ]),
         expect.objectContaining({
           title: 'Available folders',
@@ -461,9 +486,9 @@ describe('BaseStorageManager', () => {
 
       expect(window.showQuickPick).toHaveBeenCalledWith(
         expect.arrayContaining([
-          expect.objectContaining({ label: 'My Vault', value: '/' }),
-          expect.objectContaining({ label: 'Folder 1 ✓', value: '123' }),
-          expect.objectContaining({ label: 'Folder 2', value: '456' }),
+          expect.objectContaining({ label: 'My Vault ', value: '/' }),
+          expect.objectContaining({ label: 'Folder 1 ✓ ', value: '123' }),
+          expect.objectContaining({ label: 'Folder 2 ', value: '456' }),
         ]),
         expect.any(Object)
       );
@@ -493,9 +518,9 @@ describe('BaseStorageManager', () => {
 
       expect(window.showQuickPick).toHaveBeenCalledWith(
         expect.arrayContaining([
-          expect.objectContaining({ label: 'My Vault', value: '/' }),
+          expect.objectContaining({ label: 'My Vault ', value: '/' }),
           expect.objectContaining({
-            label: 'Folder 1',
+            label: 'Folder 1 ',
             value: '123',
             detail: 'Path: /My Vault / Folder 1',
           }),

--- a/test/unit/commands/storage/cliStorageManager.test.ts
+++ b/test/unit/commands/storage/cliStorageManager.test.ts
@@ -5,6 +5,7 @@ import { StatusBarSpinner } from '../../../../src/utils/helper';
 import { logger } from '../../../../src/utils/logger';
 import { safeJsonParse } from '../../../../src/utils/helper';
 import { ICliListFolderResponse, IFolder } from '../../../../src/types';
+import { CLI_SOURCE_KEEPER_DRIVE } from '../../../../src/utils/constants';
 
 // Mock dependencies
 jest.mock('../../../../src/services/cli');
@@ -146,6 +147,7 @@ describe('CliStorageManager', () => {
         name: 'My Vault',
         parentUid: '/',
         folderPath: '/',
+        source: CLI_SOURCE_KEEPER_DRIVE,
       });
       expect(result.availableFolders.length).toBeGreaterThan(0);
       expect(result.availableFolders[0]).toEqual(result.rootFolder);
@@ -463,6 +465,41 @@ describe('CliStorageManager', () => {
 
       const childFolder = result.find((f) => f.folderUid === '456');
       expect(childFolder?.folderPath).toBe('My Vault / Parent Folder / Child Folder');
+    });
+
+    it('should resolve paths from real CLI JSON (uid + Flags details only)', () => {
+      const mockCliFolders: ICliListFolderResponse[] = [
+        {
+          uid: 'G_qXL4pQ8Ebi-tewfu_iaQ',
+          name: 'Engineering 2',
+          parent_uid: '/',
+          details: 'Flags: , Parent: /',
+          source: 'KeeperDrive',
+        },
+        {
+          uid: '6fnkWl6cOahMM5FVod4lSw',
+          name: 'nested',
+          parent_uid: '/',
+          details: 'Flags: , Parent: G_qXL4pQ8Ebi-tewfu_iaQ',
+          source: 'KeeperDrive',
+        },
+        {
+          uid: 'AYAWw5zqQRasy9_ordJeKg',
+          name: 'nested 2',
+          parent_uid: '/',
+          details: 'Flags: , Parent: 6fnkWl6cOahMM5FVod4lSw',
+          source: 'KeeperDrive',
+        },
+      ];
+
+      const result = cliStorageManager.resolveFolderPaths(mockCliFolders);
+
+      expect(result.find((f) => f.name === 'nested')?.folderPath).toBe(
+        'My Vault / Engineering 2 / nested'
+      );
+      expect(result.find((f) => f.name === 'nested 2')?.folderPath).toBe(
+        'My Vault / Engineering 2 / nested / nested 2'
+      );
     });
   });
 });

--- a/test/unit/commands/storage/cliStorageManager.test.ts
+++ b/test/unit/commands/storage/cliStorageManager.test.ts
@@ -5,7 +5,7 @@ import { StatusBarSpinner } from '../../../../src/utils/helper';
 import { logger } from '../../../../src/utils/logger';
 import { safeJsonParse } from '../../../../src/utils/helper';
 import { ICliListFolderResponse, IFolder } from '../../../../src/types';
-import { CLI_SOURCE_KEEPER_DRIVE } from '../../../../src/utils/constants';
+import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER } from '../../../../src/utils/constants';
 
 // Mock dependencies
 jest.mock('../../../../src/services/cli');
@@ -74,8 +74,7 @@ describe('CliStorageManager', () => {
   });
 
   describe('ensureValidStorage', () => {
-    it('should call parent ensureValidStorage with fetchAvailableFolders', async () => {
-      // Use a folder that's NOT My Vault so validation actually calls fetchAvailableFolders
+    it('should validate current storage using getFolderByUid', async () => {
       const mockStorage: IFolder = {
         folderUid: '123',
         name: 'Test Folder',
@@ -86,21 +85,28 @@ describe('CliStorageManager', () => {
 
       mockCliService.executeCommanderCommand
         .mockResolvedValueOnce('') // sync-down
-        .mockResolvedValueOnce('[{"uid":"123","folder_uid":"123","name":"Test Folder","parent_uid":"root-folder","details":"Test Folder, Parent:root-folder"}]'); // ls
+        .mockResolvedValueOnce(
+          '[{"folder_uid":"123","name":"Test Folder"}]'
+        ); // get
 
       (safeJsonParse as jest.Mock).mockReturnValue([
         {
-          uid: '123',
           folder_uid: '123',
           name: 'Test Folder',
-          parent_uid: 'root-folder',
-          details: 'Test Folder, Parent:root-folder',
         },
       ]);
 
       const result = await cliStorageManager.ensureValidStorage();
 
-      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('sync-down');
+      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('sync-down --force');
+      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('get', [
+        '123',
+        '--format=json',
+      ]);
+      expect(mockCliService.executeCommanderCommand).not.toHaveBeenCalledWith(
+        'ls',
+        expect.anything()
+      );
       expect(result).toBe(true);
     });
   });
@@ -125,7 +131,7 @@ describe('CliStorageManager', () => {
 
       const result = await cliStorageManager.fetchAvailableFolders();
 
-      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('sync-down');
+      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('sync-down --force');
       expect(logger.logDebug).toHaveBeenCalledWith(
         'CliStorageManager: Syncing down latest records from vault'
       );
@@ -147,7 +153,7 @@ describe('CliStorageManager', () => {
         name: 'My Vault',
         parentUid: '/',
         folderPath: '/',
-        source: CLI_SOURCE_KEEPER_DRIVE,
+        source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
       });
       expect(result.availableFolders.length).toBeGreaterThan(0);
       expect(result.availableFolders[0]).toEqual(result.rootFolder);

--- a/test/unit/commands/storage/cliStorageManager.test.ts
+++ b/test/unit/commands/storage/cliStorageManager.test.ts
@@ -5,7 +5,6 @@ import { StatusBarSpinner } from '../../../../src/utils/helper';
 import { logger } from '../../../../src/utils/logger';
 import { safeJsonParse } from '../../../../src/utils/helper';
 import { ICliListFolderResponse, IFolder } from '../../../../src/types';
-import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER } from '../../../../src/utils/constants';
 
 // Mock dependencies
 jest.mock('../../../../src/services/cli');
@@ -153,7 +152,7 @@ describe('CliStorageManager', () => {
         name: 'My Vault',
         parentUid: '/',
         folderPath: '/',
-        source: CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER,
+        source: '',
       });
       expect(result.availableFolders.length).toBeGreaterThan(0);
       expect(result.availableFolders[0]).toEqual(result.rootFolder);

--- a/test/unit/commands/storage/ksmStorageManager.test.ts
+++ b/test/unit/commands/storage/ksmStorageManager.test.ts
@@ -144,6 +144,7 @@ describe('KsmStorageManager', () => {
         name: 'My Vault',
         parentUid: '/',
         folderPath: 'My Vault / My Vault', // This is what the code actually produces
+        source: '',
       });
     });
 
@@ -238,6 +239,7 @@ describe('KsmStorageManager', () => {
         name: 'Folder 1',
         parentUid: '/',
         folderPath: 'My Vault / Folder 1',
+        source: '',
       });
       expect(logger.logDebug).toHaveBeenCalledWith('Resolving paths for 1 folders');
       expect(logger.logDebug).toHaveBeenCalledWith('Resolved paths for 1 folders');
@@ -265,12 +267,14 @@ describe('KsmStorageManager', () => {
         name: 'Parent Folder',
         parentUid: '/',
         folderPath: 'My Vault / Parent Folder',
+        source: '',
       });
       expect(result[1]).toEqual({
         folderUid: '456',
         name: 'Child Folder',
         parentUid: '123',
         folderPath: 'My Vault / Parent Folder / Child Folder',
+        source: '',
       });
     });
 
@@ -305,6 +309,7 @@ describe('KsmStorageManager', () => {
         name: 'Child Folder',
         parentUid: '999',
         folderPath: 'My Vault / Child Folder',
+        source: '',
       });
     });
 
@@ -334,6 +339,7 @@ describe('KsmStorageManager', () => {
         name: 'Level 3',
         parentUid: '2',
         folderPath: 'My Vault / Level 1 / Level 2 / Level 3',
+        source: '',
       });
     });
 

--- a/test/unit/services/cli.test.ts
+++ b/test/unit/services/cli.test.ts
@@ -97,10 +97,16 @@ describe('CliService', () => {
     });
 
     it('should return true when both installed and authenticated', async () => {
-      mockExecFunction
-        .mockResolvedValueOnce({ stdout: 'version 1.0.0', stderr: '' }) // --version
-        .mockResolvedValueOnce({ stdout: 'Persistent Login: ON', stderr: '' }); // this-device
-      
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('--version')) {
+          return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
+        }
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Logged in', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
       const result = await cliService.isCLIReady();
       expect(result).toBe(true);
     });
@@ -113,10 +119,19 @@ describe('CliService', () => {
     });
 
     it('should return false when not authenticated', async () => {
-      mockExecFunction
-        .mockResolvedValueOnce({ stdout: 'version 1.0.0', stderr: '' }) // --version
-        .mockResolvedValueOnce({ stdout: 'Not logged in', stderr: '' }); // this-device
-      
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('--version')) {
+          return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
+        }
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Not logged in', stderr: '' });
+        }
+        if (command.includes('biometric verify')) {
+          return Promise.resolve({ stdout: 'No biometric', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
       const result = await cliService.isCLIReady();
       expect(result).toBe(false);
     });
@@ -247,35 +262,49 @@ describe('CliService', () => {
 
   describe('checkCommanderAuth', () => {
     it('should return true when persistent login is on', async () => {
-      mockExecFunction.mockResolvedValue({ 
-        stdout: 'Persistent Login: ON', 
-        stderr: '' 
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Logged in', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
       });
-      
+
       const result = await (cliService as unknown as any).checkCommanderAuth();
-      
+
       expect(result).toBe(true);
       expect(mockLogger.logInfo).toHaveBeenCalledWith('Keeper Commander CLI Authenticated: YES (Persistent)');
     });
 
     it('should return true when biometric authentication is detected', async () => {
-      mockExecFunction
-        .mockResolvedValueOnce({ stdout: 'Not logged in', stderr: '' }) // this-device
-        .mockResolvedValueOnce({ stdout: 'Status: SUCCESSFUL', stderr: '' }); // biometric verify
-      
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Not logged in', stderr: '' });
+        }
+        if (command.includes('biometric verify')) {
+          return Promise.resolve({ stdout: 'Status: SUCCESSFUL', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
       const result = await (cliService as unknown as any).checkCommanderAuth();
-      
+
       expect(result).toBe(true);
       expect(mockLogger.logInfo).toHaveBeenCalledWith('Keeper Commander CLI Authenticated: YES (Biometric)');
     });
 
     it('should return false when not authenticated', async () => {
-      mockExecFunction
-        .mockResolvedValueOnce({ stdout: 'Not logged in', stderr: '' }) // this-device
-        .mockResolvedValueOnce({ stdout: 'No biometric', stderr: '' }); // biometric verify
-      
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Not logged in', stderr: '' });
+        }
+        if (command.includes('biometric verify')) {
+          return Promise.resolve({ stdout: 'No biometric', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
       const result = await (cliService as unknown as any).checkCommanderAuth();
-      
+
       expect(result).toBe(false);
       expect(mockLogger.logInfo).toHaveBeenCalledWith('Keeper Commander CLI Authenticated: NO');
     });
@@ -320,19 +349,22 @@ describe('CliService', () => {
   describe('Additional Coverage Tests', () => {
     // Test lazy initialization when already initialized
     it('should skip initialization when already initialized', async () => {
-      // First call to initialize
-      mockExecFunction
-        .mockResolvedValueOnce({ stdout: 'version 1.0.0', stderr: '' })
-        .mockResolvedValueOnce({ stdout: 'Persistent Login: ON', stderr: '' });
-      
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('--version')) {
+          return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
+        }
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Logged in', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
       await cliService.isCLIReady();
-      
-      // Clear only the logDebug calls, not all mocks
+
       (mockLogger.logDebug as jest.Mock).mockClear();
-      
-      // Call lazyInitialize directly to test the skip path
+
       await (cliService as any).lazyInitialize();
-      
+
       expect(mockLogger.logDebug).toHaveBeenCalledWith(
         'CliService.lazyInitialize: Already initialized, skipping'
       );
@@ -350,12 +382,21 @@ describe('CliService', () => {
 
     // Test authentication error handling
     it('should handle authentication check failure and show error', async () => {
-      mockExecFunction
-        .mockResolvedValueOnce({ stdout: 'version 1.0.0', stderr: '' })
-        .mockResolvedValueOnce({ stdout: 'Not logged in', stderr: '' });
-      
+      mockExecFunction.mockImplementation((command: string) => {
+        if (command.includes('--version')) {
+          return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
+        }
+        if (command.includes('login-status')) {
+          return Promise.resolve({ stdout: 'Not logged in', stderr: '' });
+        }
+        if (command.includes('biometric verify')) {
+          return Promise.resolve({ stdout: 'No biometric', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
       await cliService.isCLIReady();
-      
+
       expect(mockLogger.logError).toHaveBeenCalledWith('Keeper Commander CLI is not authenticated');
       expect(mockSpinner.hide).toHaveBeenCalled();
     });

--- a/test/unit/services/cli.test.ts
+++ b/test/unit/services/cli.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../src/utils/helper', () => ({
 jest.mock('../../../src/utils/logger');
 jest.mock('child_process', () => ({
   exec: jest.fn(),
+  execFile: jest.fn(),
   spawn: jest.fn()
 }));
 jest.mock('vscode', () => ({
@@ -34,6 +35,17 @@ jest.mock('vscode', () => ({
     parse: jest.fn()
   }
 }));
+
+/**
+ * Reconstruct the equivalent shell command string from an `execFile`-style
+ * call so existing pattern-matching test logic (`includes('--version')`,
+ * `includes('biometric verify')`, ...) keeps working without rewriting every
+ * dispatch arm. This is test-only sugar — the production code never builds
+ * this string.
+ */
+function joinExecCall(file: string, args: string[] = []): string {
+  return [file, ...args].join(' ');
+}
 
 describe('CliService', () => {
   let mockContext: ExtensionContext;
@@ -97,7 +109,8 @@ describe('CliService', () => {
     });
 
     it('should return true when both installed and authenticated', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('--version')) {
           return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
         }
@@ -119,7 +132,8 @@ describe('CliService', () => {
     });
 
     it('should return false when not authenticated', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('--version')) {
           return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
         }
@@ -193,8 +207,18 @@ describe('CliService', () => {
       mockExecFunction.mockResolvedValue({ stdout: 'test output', stderr: '' });
       
       const result = await cliService.executeCommanderCommandLegacy('test-command', ['arg1', 'arg2']);
-      
-      expect(mockExecFunction).toHaveBeenCalledWith('keeper test-command arg1 arg2');
+
+      const isWindows = process.platform === 'win32';
+      const expectedFile = isWindows ? 'cmd' : 'keeper';
+      const expectedArgv = isWindows
+        ? ['/c', 'keeper', 'test-command', 'arg1', 'arg2']
+        : ['test-command', 'arg1', 'arg2'];
+
+      expect(mockExecFunction).toHaveBeenCalledWith(
+        expectedFile,
+        expectedArgv,
+        expect.objectContaining({ maxBuffer: expect.any(Number) })
+      );
       expect(result).toBe('test output');
     });
 
@@ -262,7 +286,8 @@ describe('CliService', () => {
 
   describe('checkCommanderAuth', () => {
     it('should return true when persistent login is on', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('login-status')) {
           return Promise.resolve({ stdout: 'Logged in', stderr: '' });
         }
@@ -276,7 +301,8 @@ describe('CliService', () => {
     });
 
     it('should return true when biometric authentication is detected', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('login-status')) {
           return Promise.resolve({ stdout: 'Not logged in', stderr: '' });
         }
@@ -293,7 +319,8 @@ describe('CliService', () => {
     });
 
     it('should return false when not authenticated', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('login-status')) {
           return Promise.resolve({ stdout: 'Not logged in', stderr: '' });
         }
@@ -349,7 +376,8 @@ describe('CliService', () => {
   describe('Additional Coverage Tests', () => {
     // Test lazy initialization when already initialized
     it('should skip initialization when already initialized', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('--version')) {
           return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
         }
@@ -382,7 +410,8 @@ describe('CliService', () => {
 
     // Test authentication error handling
     it('should handle authentication check failure and show error', async () => {
-      mockExecFunction.mockImplementation((command: string) => {
+      mockExecFunction.mockImplementation((file: string, args: string[]) => {
+        const command = joinExecCall(file, args);
         if (command.includes('--version')) {
           return Promise.resolve({ stdout: 'version 1.0.0', stderr: '' });
         }
@@ -494,11 +523,50 @@ describe('CliService', () => {
     // Test executeCommanderCommandLegacyRaw
     it('should execute raw command without cleaning', async () => {
       mockExecFunction.mockResolvedValue({ stdout: 'raw output', stderr: 'raw error' });
-      
+
       const result = await (cliService as any).executeCommanderCommandLegacyRaw('test-command', ['arg1']);
-      
+
+      const isWindows = process.platform === 'win32';
+      const expectedFile = isWindows ? 'cmd' : 'keeper';
+      const expectedArgv = isWindows
+        ? ['/c', 'keeper', 'test-command', 'arg1']
+        : ['test-command', 'arg1'];
+
       expect(result).toEqual({ stdout: 'raw output', stderr: 'raw error' });
-      expect(mockExecFunction).toHaveBeenCalledWith('keeper test-command arg1');
+      expect(mockExecFunction).toHaveBeenCalledWith(
+        expectedFile,
+        expectedArgv,
+        expect.objectContaining({ maxBuffer: expect.any(Number) })
+      );
+    });
+
+    // Security regression test: shell metacharacters in args must be passed
+    // as a single argv element, never to a shell. With execFile/array-args
+    // there is no shell, so the metacharacters are inert.
+    it('should pass shell metacharacters as a single argv element with no shell involved', async () => {
+      mockExecFunction.mockResolvedValue({ stdout: 'ok', stderr: '' });
+
+      const malicious = 'foo;cd $HOME && id > /tmp/pwned.txt;#';
+      await (cliService as any).executeCommanderCommandLegacyRaw('get', [
+        malicious,
+        '--format=json',
+      ]);
+
+      const [file, argv, options] = mockExecFunction.mock.calls[0];
+
+      // No call should ever target a shell binary.
+      expect(file).not.toMatch(/\/(?:ba)?sh$/);
+      expect(file).not.toBe('sh');
+      expect(file).not.toBe('bash');
+      expect(file).not.toBe('zsh');
+      // Args must be a real array — not a single shell-parsed string.
+      expect(Array.isArray(argv)).toBe(true);
+      // The malicious payload must appear as ONE argv entry, byte-for-byte.
+      expect(argv).toContain(malicious);
+      // options must be passed (covers maxBuffer plumbing).
+      expect(options).toEqual(
+        expect.objectContaining({ maxBuffer: expect.any(Number) })
+      );
     });
 
     // Test cleanCommanderNoise function

--- a/test/unit/services/cli.test.ts
+++ b/test/unit/services/cli.test.ts
@@ -123,6 +123,24 @@ describe('CliService', () => {
   });
 
   describe('executeCommanderCommand', () => {
+    it('should reject get command when record UID contains a newline', async () => {
+      await expect(
+        cliService.executeCommanderCommand('get', [
+          'abc\nksm.bat\n',
+          '--format=json',
+        ])
+      ).rejects.toThrow(/control characters/i);
+    });
+
+    it('should reject get command when record UID has invalid characters', async () => {
+      await expect(
+        cliService.executeCommanderCommand('get', [
+          'not valid!',
+          '--format=json',
+        ])
+      ).rejects.toThrow(/Invalid Keeper record UID/i);
+    });
+
     it('should use legacy mode when not initialized', async () => {
       mockExecFunction.mockResolvedValue({ stdout: 'test output', stderr: '' });
       

--- a/test/unit/utils/helper.test.ts
+++ b/test/unit/utils/helper.test.ts
@@ -27,7 +27,10 @@ import {
   parseKeeperReference,
   StatusBarSpinner,
   documentMatcher,
-  isEnvironmentFile
+  isEnvironmentFile,
+  hasKeeperNotationControlCharacters,
+  isValidKeeperRecordUid,
+  assertSafeKeeperNotationEnvValue,
 } from '../../../src/utils/helper';
 import { KEEPER_NOTATION_FIELD_TYPES } from '../../../src/utils/constants';
 import { logger } from '../../../src/utils/logger';
@@ -86,6 +89,64 @@ describe('Helper Functions', () => {
       const result = validateKeeperReference(invalidReference);
       
       expect(result).toBe(false);
+    });
+
+    it('should reject multiline keeper reference (command injection PoC)', () => {
+      const multilineReference =
+        'keeper://abc\nksm.bat\n/field/password';
+      expect(validateKeeperReference(multilineReference)).toBe(false);
+    });
+
+    it('should reject record UID with invalid characters', () => {
+      const invalidUidReference = 'keeper://not valid!/field/password';
+      expect(validateKeeperReference(invalidUidReference)).toBe(false);
+    });
+
+    it('should accept real-style record UID', () => {
+      const reference =
+        'keeper://PD-SYa1nmuiK1M1xQ0IYRA/field/password';
+      expect(validateKeeperReference(reference)).toBe(true);
+    });
+  });
+
+  describe('hasKeeperNotationControlCharacters', () => {
+    it('should detect newline, carriage return, tab, and null', () => {
+      expect(hasKeeperNotationControlCharacters('a\nb')).toBe(true);
+      expect(hasKeeperNotationControlCharacters('a\rb')).toBe(true);
+      expect(hasKeeperNotationControlCharacters('a\tb')).toBe(true);
+      expect(hasKeeperNotationControlCharacters('a\0b')).toBe(true);
+    });
+
+    it('should allow normal keeper notation strings', () => {
+      expect(
+        hasKeeperNotationControlCharacters(
+          'keeper://PD-SYa1nmuiK1M1xQ0IYRA/field/password'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('isValidKeeperRecordUid', () => {
+    it('should accept URL-safe base64-style UIDs', () => {
+      expect(isValidKeeperRecordUid('PD-SYa1nmuiK1M1xQ0IYRA')).toBe(true);
+      expect(isValidKeeperRecordUid('record123')).toBe(true);
+    });
+
+    it('should reject UIDs with slashes, spaces, or newlines', () => {
+      expect(isValidKeeperRecordUid('abc\nksm')).toBe(false);
+      expect(isValidKeeperRecordUid('foo/bar')).toBe(false);
+      expect(isValidKeeperRecordUid('has space')).toBe(false);
+    });
+  });
+
+  describe('assertSafeKeeperNotationEnvValue', () => {
+    it('should throw for control characters in env value', () => {
+      expect(() =>
+        assertSafeKeeperNotationEnvValue(
+          'keeper://abc\nksm.bat\n/field/password',
+          'API_PASSWORD'
+        )
+      ).toThrow(/control character/i);
     });
   });
 
@@ -180,6 +241,24 @@ describe('Helper Functions', () => {
     it('should return null for empty reference', () => {
       const result = parseKeeperReference('');
       expect(result).toBeNull();
+    });
+
+    it('should return null for multiline keeper reference', () => {
+      const result = parseKeeperReference(
+        'keeper://abc\nksm.bat\n/field/password'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should parse real-style record UID', () => {
+      const result = parseKeeperReference(
+        'keeper://G_qXL4pQ8Ebi-tewfu_iaQ/field/password'
+      );
+      expect(result).toEqual({
+        recordUid: 'G_qXL4pQ8Ebi-tewfu_iaQ',
+        fieldType: 'field',
+        itemName: 'password',
+      });
     });
   });
 

--- a/test/unit/utils/helper.test.ts
+++ b/test/unit/utils/helper.test.ts
@@ -56,18 +56,20 @@ describe('Helper Functions', () => {
   describe('validateKeeperReference', () => {
     it('should validate correct keeper reference', () => {
       // Use a reference that matches the FIELD pattern: field or custom_field
-      const validReference = 'keeper://record123/field/MyPassword';
+      const validReference =
+        'keeper://PD-SYa1nmuiK1M1xQ0IYRA/field/MyPassword';
       const result = validateKeeperReference(validReference);
-      
+
       expect(result).toBe(true);
       expect(logger.logDebug).toHaveBeenCalledWith(`Validating keeper reference: ${validReference}`);
       expect(logger.logDebug).toHaveBeenCalledWith(`Keeper reference validation result: ${result}`);
     });
 
     it('should validate custom_field reference', () => {
-      const validReference = 'keeper://record123/custom_field/MyCustomField';
+      const validReference =
+        'keeper://PD-SYa1nmuiK1M1xQ0IYRA/custom_field/MyCustomField';
       const result = validateKeeperReference(validReference);
-      
+
       expect(result).toBe(true);
     });
 
@@ -129,13 +131,19 @@ describe('Helper Functions', () => {
   describe('isValidKeeperRecordUid', () => {
     it('should accept URL-safe base64-style UIDs', () => {
       expect(isValidKeeperRecordUid('PD-SYa1nmuiK1M1xQ0IYRA')).toBe(true);
-      expect(isValidKeeperRecordUid('record123')).toBe(true);
+      expect(isValidKeeperRecordUid('G_qXL4pQ8Ebi-tewfu_iaQ')).toBe(true);
     });
 
     it('should reject UIDs with slashes, spaces, or newlines', () => {
       expect(isValidKeeperRecordUid('abc\nksm')).toBe(false);
       expect(isValidKeeperRecordUid('foo/bar')).toBe(false);
       expect(isValidKeeperRecordUid('has space')).toBe(false);
+    });
+
+    it('should reject UIDs that are not exactly 22 characters', () => {
+      expect(isValidKeeperRecordUid('record123')).toBe(false);
+      expect(isValidKeeperRecordUid('PD-SYa1nmuiK1M1xQ0IYR')).toBe(false);
+      expect(isValidKeeperRecordUid('PD-SYa1nmuiK1M1xQ0IYRAA')).toBe(false);
     });
   });
 
@@ -152,12 +160,12 @@ describe('Helper Functions', () => {
 
   describe('createKeeperReference', () => {
     it('should create valid keeper reference', () => {
-      const recordUid = 'record123';
-      const fieldType = KEEPER_NOTATION_FIELD_TYPES.FIELD; // Use the correct enum value
+      const recordUid = 'PD-SYa1nmuiK1M1xQ0IYRA';
+      const fieldType = KEEPER_NOTATION_FIELD_TYPES.FIELD;
       const itemName = 'MyPassword';
-      
+
       const result = createKeeperReference(recordUid, fieldType, itemName);
-      
+
       expect(result).toBe(`keeper://${recordUid}/${fieldType}/${itemName}`);
       expect(logger.logDebug).toHaveBeenCalledWith(`Creating keeper reference - recordUid: ${recordUid}, fieldType: ${fieldType}, itemName: ${itemName}`);
       expect(logger.logDebug).toHaveBeenCalledWith(`Created keeper reference: ${result}`);
@@ -165,16 +173,31 @@ describe('Helper Functions', () => {
 
     it('should return null when recordUid is missing', () => {
       const result = createKeeperReference('', KEEPER_NOTATION_FIELD_TYPES.FIELD, 'MyPassword');
-      
+
       expect(result).toBeNull();
       expect(logger.logError).toHaveBeenCalledWith('recordUid is required to create a keeper reference');
     });
 
     it('should return null when itemName is missing', () => {
-      const result = createKeeperReference('record123', KEEPER_NOTATION_FIELD_TYPES.FIELD, '');
-      
+      const result = createKeeperReference(
+        'PD-SYa1nmuiK1M1xQ0IYRA',
+        KEEPER_NOTATION_FIELD_TYPES.FIELD,
+        ''
+      );
+
       expect(result).toBeNull();
       expect(logger.logError).toHaveBeenCalledWith('itemName is required to create a keeper reference');
+    });
+
+    it('should return null when recordUid is not a valid 22-char URL-safe token', () => {
+      const result = createKeeperReference(
+        'record123',
+        KEEPER_NOTATION_FIELD_TYPES.FIELD,
+        'MyPassword'
+      );
+
+      expect(result).toBeNull();
+      expect(logger.logError).toHaveBeenCalledWith('recordUid contains invalid characters');
     });
   });
 
@@ -206,12 +229,11 @@ describe('Helper Functions', () => {
 
   describe('parseKeeperReference', () => {
     it('should parse valid keeper reference', () => {
-      // Use a reference that matches the FIELD pattern
-      const reference = 'keeper://record123/field/MyPassword';
+      const reference = 'keeper://PD-SYa1nmuiK1M1xQ0IYRA/field/MyPassword';
       const result = parseKeeperReference(reference);
-      
+
       expect(result).toEqual({
-        recordUid: 'record123',
+        recordUid: 'PD-SYa1nmuiK1M1xQ0IYRA',
         fieldType: 'field',
         itemName: 'MyPassword'
       });
@@ -220,11 +242,12 @@ describe('Helper Functions', () => {
     });
 
     it('should parse custom_field reference', () => {
-      const reference = 'keeper://record123/custom_field/MyCustomField';
+      const reference =
+        'keeper://PD-SYa1nmuiK1M1xQ0IYRA/custom_field/MyCustomField';
       const result = parseKeeperReference(reference);
-      
+
       expect(result).toEqual({
-        recordUid: 'record123',
+        recordUid: 'PD-SYa1nmuiK1M1xQ0IYRA',
         fieldType: 'custom_field',
         itemName: 'MyCustomField'
       });

--- a/test/unit/utils/helper.test.ts
+++ b/test/unit/utils/helper.test.ts
@@ -26,7 +26,6 @@ import {
   promisifyExec,
   parseKeeperReference,
   StatusBarSpinner,
-  resolveFolderPaths,
   documentMatcher,
   isEnvironmentFile
 } from '../../../src/utils/helper';
@@ -225,48 +224,6 @@ describe('Helper Functions', () => {
       spinner.dispose();
       
       expect(mockStatusBarItem.dispose).toHaveBeenCalled();
-    });
-  });
-
-  describe('resolveFolderPaths', () => {
-    it('should resolve simple folder structure', () => {
-      const folders: any[] = [
-        { folder_uid: 'folder1', name: 'Folder1', parent_uid: '/' },
-        { folder_uid: 'folder2', name: 'Folder2', parent_uid: 'folder1' }
-      ];
-      
-      const result = resolveFolderPaths(folders);
-      
-      expect(result).toHaveLength(2);
-      expect(result[0].folderPath).toBe('My Vault / Folder1');
-      expect(result[1].folderPath).toBe('My Vault / Folder1 / Folder2');
-    });
-
-    it('should resolve complex nested structure', () => {
-      const folders: any[] = [
-        { folder_uid: 'root', name: 'Root', parent_uid: '/' },
-        { folder_uid: 'level1', name: 'Level1', parent_uid: 'root' },
-        { folder_uid: 'level2', name: 'Level2', parent_uid: 'level1' },
-        { folder_uid: 'level3', name: 'Level3', parent_uid: 'level2' }
-      ];
-      
-      const result = resolveFolderPaths(folders);
-      
-      expect(result).toHaveLength(4);
-      expect(result[3].folderPath).toBe('My Vault / Root / Level1 / Level2 / Level3');
-    });
-
-    it('should handle missing parent folders gracefully', () => {
-      const folders: any[] = [
-        { folder_uid: 'folder1', name: 'Folder1', parent_uid: 'missing' },
-        { folder_uid: 'folder2', name: 'Folder2', parent_uid: '/' }
-      ];
-      
-      const result = resolveFolderPaths(folders);
-      
-      expect(result).toHaveLength(2);
-      expect(result[0].folderPath).toBe('My Vault / Folder1');
-      expect(result[1].folderPath).toBe('My Vault / Folder2');
     });
   });
 


### PR DESCRIPTION
- **Nested Share Folder Support** (In CLI mode): Added support for Keeper's new nested share folders alongside classic folders.
  - Folder picker now distinguishes between `(Nested Share Folder)` and `(Classic Folder)` folders.
- **Permission Model Selection in My Vault** (In CLI mode): When the current storage is `My Vault` (root), `Generate Password` and `Save Value to Vault` now prompt the user to choose between:
  - `Use classic permission model` — creates the record with classic permission model.
  - `Use new permission model` — creates the record with new permission model.
- **Security fixes**:
  - Reject Keeper references containing line breaks or other control characters in `.env` files used by the `Run Securely` command.
  - Validate Keeper record UIDs and arguments passed to Keeper Commander, rejecting values that contain control characters or unsafe characters.
  - Hardened `createKeeperReference` and `validateKeeperReference` to reject record UIDs that are not URL-safe base64 tokens.
  - The legacy Keeper Commander executor now spawns the CLI directly via `execFile` with a tokenized argv instead of `exec` with a concatenated command string. No shell is involved, so shell metacharacters in arguments cannot be interpreted as syntax even if they bypass upstream validation. The persistent-process path already used this model; the legacy path now matches it.
  - Declared `capabilities.untrustedWorkspaces.supported = false` so the extension is disabled by default in VS Code Restricted Mode. The Run Securely command parses workspace `.env` files and invokes a local CLI; running in untrusted workspaces is not safe.
- **Performance**:
  - Faster authentication check: replaced the `this-device` probe with `login-status`, which is significantly quicker for vaults with large amounts of data. Auth-check timeout extended to 5 minutes for slow networks/setups.
  - `sync-down` is now invoked with `--force` so that the latest records are always fetched when retrieving folders or records.
- **Dependencies**:
  - Bumped `webpack` to `^5.105.2`.
  - Added overrides for `diff` and `serialize-javascript` to address transitive vulnerabilities.