### PR TITLE
Added validation to reject control characters in field data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.2.0
+
+- **Security fixes**:
+  - **Save in Keeper Security** and **Generate Password** now escape backslashes and double quotes in record titles, field values, and folder UIDs before building `record-add` / `nsf-record-add` arguments. Repository-controlled secret text (e.g. from a malicious `.env` or source file) can no longer break out of quoted Commander arguments and inject additional CLI flags such as `--title=` when the extension writes to the persistent Commander shell.
+  - Reject control characters in record-add field data before the command is sent to Keeper Commander.
+
 ## 2.1.0
 
 - **Nested Share Folder Support** (In CLI mode): Added support for Keeper's new nested share folders alongside classic folders.
@@ -7,6 +13,7 @@
 - **Permission Model Selection in My Vault** (In CLI mode): When the current storage is `My Vault` (root), `Generate Password` and `Save Value to Vault` now prompt the user to choose between:
   - `Use classic permission model` — creates the record with classic permission model.
   - `Use new permission model` — creates the record with new permission model.
+- **Combined Record Listing for My Vault** (In CLI mode): **Get from Keeper Security** fetches both classic and nested share folder records and shows them together in a single list when current storage is `My Vault`.
 - **Security fixes**:
   - Reject Keeper references containing line breaks or other control characters in `.env` files used by the `Run Securely` command.
   - Validate Keeper record UIDs and arguments passed to Keeper Commander, rejecting values that contain control characters or unsafe characters.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ks-vscode",
   "displayName": "Keeper Security",
   "description": "Never commit secrets to your code again - secure them in your Keeper vault",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "publisher": "KeeperSecurityDev",
   "galleryBanner": {

--- a/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
+++ b/src/commands/handlers/cli/cliGeneratePasswordHandler.ts
@@ -14,7 +14,7 @@ import {
   CLI_LOGGER_ERROR_MESSAGES,
 } from '../../../utils/cli-messages';
 import { CliStorageManager } from '../../storage/cliStorageManager';
-import { resolveRecordAddCommand } from '../../utils/cliRecordCommandResolver';
+import { resolveRecordAddCommand, buildRecordAddArgs } from '../../utils/cliRecordCommandResolver';
 
 export class CliGeneratePasswordHandler extends BaseGeneratePasswordHandler {
   constructor(
@@ -68,16 +68,13 @@ export class CliGeneratePasswordHandler extends BaseGeneratePasswordHandler {
 
       this.spinner.show(CLI_INFO_MESSAGES.GENERATING_PASSWORD);
 
-      const args = [
-        `--title="${recordName}"`,
-        `--record-type=${KEEPER_RECORD_TYPES.LOGIN}`,
-        `"password"=$GEN`,
-      ];
-
-      // if currentStorage is not "My Vault", then add folder to args
-      if (currentStorage?.folderUid !== '/') {
-        args.push(`--folder="${currentStorage?.folderUid}"`);
-      }
+      const args = buildRecordAddArgs({
+        title: recordName,
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey: 'password',
+        fieldValue: { kind: 'generate', token: '$GEN' },
+        folderUid: currentStorage?.folderUid,
+      });
 
       const recordUid = await this.cliService.executeCommanderCommand(
         recordCommandToExecute, 

--- a/src/commands/handlers/cli/cliSaveValueHandler.ts
+++ b/src/commands/handlers/cli/cliSaveValueHandler.ts
@@ -14,7 +14,7 @@ import {
   KEEPER_NOTATION_FIELD_TYPES,
   KEEPER_RECORD_TYPES,
 } from '../../../utils/constants';
-import { resolveRecordAddCommand } from '../../utils/cliRecordCommandResolver';
+import { resolveRecordAddCommand, buildRecordAddArgs } from '../../utils/cliRecordCommandResolver';
 
 export class CliSaveValueHandler extends BaseSaveValueHandler {
   constructor(
@@ -91,25 +91,14 @@ export class CliSaveValueHandler extends BaseSaveValueHandler {
 
       this.spinner.show(CLI_INFO_MESSAGES.SAVING_SECRET);
 
-      /**
-       *
-       * [<FIELD_SET>][<FIELD_TYPE>][<FIELD_LABEL>]=[FIELD_VALUE]
-       *
-       * `"c.${this.getFieldType(recordFieldName)}.${recordFieldName}"="${selectedText}"`
-       *
-       * Create custom field with detect recordFieldName that can be secret or text
-       */
-
-      const args = [
-        `--title="${recordName}"`,
-        `--record-type=${KEEPER_RECORD_TYPES.LOGIN}`,
-        `"c.${this.getFieldType(recordFieldName)}.${recordFieldName}"="${selectedText}"`,
-      ];
-
-      // if currentStorage is not "My Vault", then add folder to args
-      if (currentStorage?.folderUid !== '/') {
-        args.push(`--folder="${currentStorage?.folderUid}"`);
-      }
+      const fieldKey = `c.${this.getFieldType(recordFieldName)}.${recordFieldName}`;
+      const args = buildRecordAddArgs({
+        title: recordName,
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey,
+        fieldValue: { kind: 'literal', value: selectedText },
+        folderUid: currentStorage?.folderUid,
+      });
 
       const recordUid = await this.cliService.executeCommanderCommand(
         recordCommandToExecute,

--- a/src/commands/utils/cliRecordCommandResolver.ts
+++ b/src/commands/utils/cliRecordCommandResolver.ts
@@ -1,8 +1,12 @@
 import { window } from 'vscode';
 import { IFolder } from '../../types';
-import { commonQuickPickOptions } from '../../utils/helper';
-import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER } from '../../utils/constants';
-import { CLI_INFO_MESSAGES } from '../../utils/cli-messages';
+import {
+  commonQuickPickOptions,
+  escapeCommanderDoubleQuotedValue,
+  hasKeeperNotationControlCharacters,
+} from '../../utils/helper';
+import { CLI_FOLDER_SOURCE_NESTED_SHARE_FOLDER, KEEPER_RECORD_TYPES } from '../../utils/constants';
+import { CLI_ERROR_MESSAGES, CLI_INFO_MESSAGES } from '../../utils/cli-messages';
 
 export const RECORD_ADD_COMMANDS = {
   CLASSIC: 'record-add',
@@ -11,6 +15,69 @@ export const RECORD_ADD_COMMANDS = {
 
 export type RecordAddCommand =
   (typeof RECORD_ADD_COMMANDS)[keyof typeof RECORD_ADD_COMMANDS];
+
+export type RecordAddFieldValue =
+  | { kind: 'literal'; value: string }
+  | { kind: 'generate'; token: '$GEN' };
+
+export interface BuildRecordAddArgsOptions {
+  title: string;
+  recordType: KEEPER_RECORD_TYPES;
+  fieldKey: string;
+  fieldValue: RecordAddFieldValue;
+  folderUid?: string;
+}
+
+function assertSafeCommanderRecordAddValue(value: string, label: string): void {
+  if (hasKeeperNotationControlCharacters(value)) {
+    throw new Error(
+      `${CLI_ERROR_MESSAGES.INVALID_COMMANDER_RECORD_ADD_VALUE} (${label})`
+    );
+  }
+}
+
+function formatRecordAddFieldAssignment(
+  fieldKey: string,
+  fieldValue: RecordAddFieldValue
+): string {
+  const escapedKey = escapeCommanderDoubleQuotedValue(fieldKey);
+
+  if (fieldValue.kind === 'generate') {
+    return `"${escapedKey}"=${fieldValue.token}`;
+  }
+
+  assertSafeCommanderRecordAddValue(fieldValue.value, 'field value');
+  return `"${escapedKey}"="${escapeCommanderDoubleQuotedValue(fieldValue.value)}"`;
+}
+
+/**
+ * Build argv-style fragments for `record-add` / `nsf-record-add`.
+ * User- and repository-controlled values are escaped before quoting so they
+ * cannot inject additional Keeper Commander flags when joined for the
+ * persistent shell.
+ */
+export function buildRecordAddArgs(
+  options: BuildRecordAddArgsOptions
+): string[] {
+  const { title, recordType, fieldKey, fieldValue, folderUid } = options;
+
+  assertSafeCommanderRecordAddValue(title, 'title');
+  assertSafeCommanderRecordAddValue(fieldKey, 'field key');
+
+  const args = [
+    `--title="${escapeCommanderDoubleQuotedValue(title)}"`,
+    `--record-type=${recordType}`,
+    formatRecordAddFieldAssignment(fieldKey, fieldValue),
+  ];
+
+  // if currentStorage is not "My Vault", then add folder to args
+  if (folderUid && folderUid !== '/') {
+    assertSafeCommanderRecordAddValue(folderUid, 'folder');
+    args.push(`--folder="${escapeCommanderDoubleQuotedValue(folderUid)}"`);
+  }
+
+  return args;
+}
 
 /**
  * Resolves which `record-add` command variant to use based on the current storage.

--- a/src/services/cli.ts
+++ b/src/services/cli.ts
@@ -4,6 +4,7 @@ import {
   hasKeeperNotationControlCharacters,
   isValidKeeperRecordUid,
   promisifyExec,
+  serializeCommanderShellCommand,
   StatusBarSpinner,
 } from '../utils/helper';
 import { execFile, spawn, ChildProcess } from 'child_process';
@@ -617,7 +618,9 @@ export class CliService {
             this.persistentProcess?.stdin?.write('\x03');
 
             setTimeout(() => {
-              this.persistentProcess?.stdin?.write(`${command} ${args.join(' ')}\n`);
+              this.persistentProcess?.stdin?.write(
+                serializeCommanderShellCommand(command, args)
+              );
             }, 500); // 0.5 seconds timeout
             return;
           }
@@ -670,7 +673,9 @@ export class CliService {
       this.persistentProcess?.stderr?.on('data', onStderr);
 
       // Send command to Keeper Commander process via stdin
-      this.persistentProcess?.stdin?.write(`${command} ${args.join(' ')}\n`);
+      this.persistentProcess?.stdin?.write(
+        serializeCommanderShellCommand(command, args)
+      );
 
       // Wait for command completion by checking for shell prompt
       const checkCompletion = (): void => {

--- a/src/utils/cli-messages.ts
+++ b/src/utils/cli-messages.ts
@@ -25,6 +25,8 @@ export const CLI_ERROR_MESSAGES = {
   FAILED_TO_SWITCH_TO_KSM: 'Failed to switch to KSM mode',
   INVALID_COMMANDER_ARGUMENT:
     'Invalid Keeper Commander argument: control characters are not allowed.',
+  INVALID_COMMANDER_RECORD_ADD_VALUE:
+    'Value contains characters that are not allowed in Keeper Commander record fields (control characters).',
   INVALID_COMMANDER_RECORD_UID: 'Invalid Keeper record UID.',
 } as const;
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -21,6 +21,27 @@ export function hasKeeperNotationControlCharacters(value: string): boolean {
   return KEEPER_NOTATION_CONTROL_CHAR_PATTERN.test(value);
 }
 
+/**
+ * Escape a value embedded inside Keeper Commander double-quoted tokens.
+ * Backslashes and double quotes are escaped so repository-controlled field
+ * data cannot break out and inject additional CLI flags (e.g. `--title=`).
+ */
+export function escapeCommanderDoubleQuotedValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Join a Commander shell command and pre-built args into the line written to
+ * the persistent REPL stdin. Centralizes serialization so escaping rules stay
+ * consistent across call sites.
+ */
+export function serializeCommanderShellCommand(
+  command: string,
+  args: string[]
+): string {
+  return `${command} ${args.join(' ')}\n`;
+}
+
 export function isValidKeeperRecordUid(recordUid: string): boolean {
   return KEEPER_RECORD_UID_PATTERN.test(recordUid);
 }

--- a/test/unit/commands/handlers/cli/cliSaveValueHandler.test.ts
+++ b/test/unit/commands/handlers/cli/cliSaveValueHandler.test.ts
@@ -118,6 +118,33 @@ describe('CliSaveValueHandler', () => {
       expect(mockSpinner.hide).toHaveBeenCalled();
     });
 
+    it('should escape quote-breakout payloads in selected secret text', async () => {
+      const maliciousValue = 'SAFE_VALUE" --title="SAFE_INJECTED';
+      spyGetSelectedText().mockResolvedValue(maliciousValue);
+      mockCliService.isCLIReady.mockResolvedValue(true);
+      spyGetRecordNameFromUser().mockResolvedValue('SAFE_ORIGINAL');
+      spyGetSecretFieldNameFromUser().mockResolvedValue('password');
+      mockStorageManager.ensureValidStorage.mockResolvedValue(true);
+      mockStorageManager.getCurrentStorage.mockReturnValue({
+        folderUid: '/',
+        name: 'My Vault',
+        parentUid: '/',
+        folderPath: '/',
+      });
+      spyGetFieldType().mockReturnValue('secret');
+      mockCliService.executeCommanderCommand.mockResolvedValue('rec123');
+      mockedCreateKeeperReference.mockReturnValue('keeper://rec123/custom_field/password');
+      spyInsert().mockResolvedValue(true);
+
+      await handler.execute();
+
+      expect(mockCliService.executeCommanderCommand).toHaveBeenCalledWith('record-add', [
+        '--title="SAFE_ORIGINAL"',
+        `--record-type=${KEEPER_RECORD_TYPES.LOGIN}`,
+        `"c.secret.password"="SAFE_VALUE\\" --title=\\"SAFE_INJECTED"`,
+      ]);
+    });
+
     it('should save to custom folder (adds --folder)', async () => {
       spyGetSelectedText().mockResolvedValue('secret-value');
       mockCliService.isCLIReady.mockResolvedValue(true);

--- a/test/unit/commands/utils/cliRecordCommandResolver.test.ts
+++ b/test/unit/commands/utils/cliRecordCommandResolver.test.ts
@@ -1,0 +1,147 @@
+import {
+  buildRecordAddArgs,
+  resolveRecordAddCommand,
+  RECORD_ADD_COMMANDS,
+} from '../../../../src/commands/utils/cliRecordCommandResolver';
+import {
+  escapeCommanderDoubleQuotedValue,
+  serializeCommanderShellCommand,
+} from '../../../../src/utils/helper';
+import { KEEPER_RECORD_TYPES } from '../../../../src/utils/constants';
+import { CLI_ERROR_MESSAGES } from '../../../../src/utils/cli-messages';
+import { window } from 'vscode';
+
+jest.mock('vscode', () => ({
+  ...jest.requireActual('vscode'),
+  window: {
+    showQuickPick: jest.fn(),
+    createOutputChannel: jest.fn(() => ({
+      appendLine: jest.fn(),
+      show: jest.fn(),
+      hide: jest.fn(),
+      dispose: jest.fn(),
+    })),
+  },
+}));
+
+describe('cliRecordCommandResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildRecordAddArgs', () => {
+    it('should build classic record-add args with quoted field value', () => {
+      const args = buildRecordAddArgs({
+        title: 'My Record',
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey: 'c.secret.password',
+        fieldValue: { kind: 'literal', value: 'secret-value' },
+      });
+
+      expect(args).toEqual([
+        '--title="My Record"',
+        `--record-type=${KEEPER_RECORD_TYPES.LOGIN}`,
+        '"c.secret.password"="secret-value"',
+      ]);
+    });
+
+    it('should include folder arg when folderUid is not root', () => {
+      const args = buildRecordAddArgs({
+        title: 'My Record',
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey: 'c.secret.apiKey',
+        fieldValue: { kind: 'literal', value: 'secret-value' },
+        folderUid: 'folder123',
+      });
+
+      expect(args).toContain('--folder="folder123"');
+    });
+
+    it('should build generate-password field assignment without quoting $GEN', () => {
+      const args = buildRecordAddArgs({
+        title: 'Generated',
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey: 'password',
+        fieldValue: { kind: 'generate', token: '$GEN' },
+      });
+
+      expect(args).toEqual([
+        '--title="Generated"',
+        `--record-type=${KEEPER_RECORD_TYPES.LOGIN}`,
+        '"password"=$GEN',
+      ]);
+    });
+
+    it('should escape quote-breakout payloads in field values (Save-to-Vault PoC)', () => {
+      const maliciousValue = 'SAFE_VALUE" --title="SAFE_INJECTED';
+      const args = buildRecordAddArgs({
+        title: 'SAFE_ORIGINAL',
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey: 'c.secret.password',
+        fieldValue: { kind: 'literal', value: maliciousValue },
+      });
+
+      expect(args[2]).toBe(
+        `"c.secret.password"="${escapeCommanderDoubleQuotedValue(maliciousValue)}"`
+      );
+
+      const shellLine = serializeCommanderShellCommand('record-add', args);
+
+      // Must not contain an unescaped second --title flag outside field data.
+      expect(shellLine).not.toMatch(
+        /"c\.secret\.password"="SAFE_VALUE" --title="SAFE_INJECTED"/
+      );
+      expect(shellLine).toContain('SAFE_VALUE\\" --title=\\"SAFE_INJECTED');
+    });
+
+    it('should escape quote-breakout payloads in record title', () => {
+      const maliciousTitle = 'SAFE_ORIGINAL" --title="SAFE_INJECTED';
+      const args = buildRecordAddArgs({
+        title: maliciousTitle,
+        recordType: KEEPER_RECORD_TYPES.LOGIN,
+        fieldKey: 'c.secret.password',
+        fieldValue: { kind: 'literal', value: 'secret-value' },
+      });
+
+      expect(args[0]).toBe(
+        `--title="${escapeCommanderDoubleQuotedValue(maliciousTitle)}"`
+      );
+
+      const shellLine = serializeCommanderShellCommand('record-add', args);
+      expect(shellLine).not.toMatch(
+        /--title="SAFE_ORIGINAL" --title="SAFE_INJECTED"/
+      );
+    });
+
+    it('should reject control characters in field values', () => {
+      expect(() =>
+        buildRecordAddArgs({
+          title: 'My Record',
+          recordType: KEEPER_RECORD_TYPES.LOGIN,
+          fieldKey: 'c.secret.password',
+          fieldValue: { kind: 'literal', value: 'bad\nvalue' },
+        })
+      ).toThrow(CLI_ERROR_MESSAGES.INVALID_COMMANDER_RECORD_ADD_VALUE);
+    });
+  });
+
+  describe('resolveRecordAddCommand', () => {
+    it('should prompt for permission model when storage is My Vault', async () => {
+      (window.showQuickPick as jest.Mock).mockResolvedValue({
+        label: 'Use classic permission model',
+        value: RECORD_ADD_COMMANDS.CLASSIC,
+      });
+
+      const result = await resolveRecordAddCommand({
+        folderUid: '/',
+        name: 'My Vault',
+        parentUid: '/',
+        folderPath: '/',
+        source: '',
+      });
+
+      expect(result).toBe(RECORD_ADD_COMMANDS.CLASSIC);
+      expect(window.showQuickPick).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/utils/helper.test.ts
+++ b/test/unit/utils/helper.test.ts
@@ -29,6 +29,8 @@ import {
   documentMatcher,
   isEnvironmentFile,
   hasKeeperNotationControlCharacters,
+  escapeCommanderDoubleQuotedValue,
+  serializeCommanderShellCommand,
   isValidKeeperRecordUid,
   assertSafeKeeperNotationEnvValue,
 } from '../../../src/utils/helper';
@@ -125,6 +127,28 @@ describe('Helper Functions', () => {
           'keeper://PD-SYa1nmuiK1M1xQ0IYRA/field/password'
         )
       ).toBe(false);
+    });
+  });
+
+  describe('escapeCommanderDoubleQuotedValue', () => {
+    it('should escape backslashes and double quotes', () => {
+      expect(escapeCommanderDoubleQuotedValue('SAFE_VALUE" --title="SAFE_INJECTED')).toBe(
+        'SAFE_VALUE\\" --title=\\"SAFE_INJECTED'
+      );
+      expect(escapeCommanderDoubleQuotedValue('path\\to\\secret')).toBe(
+        'path\\\\to\\\\secret'
+      );
+    });
+  });
+
+  describe('serializeCommanderShellCommand', () => {
+    it('should join command and args with a trailing newline', () => {
+      expect(
+        serializeCommanderShellCommand('record-add', [
+          '--title="My Record"',
+          '--record-type=login',
+        ])
+      ).toBe('record-add --title="My Record" --record-type=login\n');
     });
   });
 


### PR DESCRIPTION
Release 2.2.0: Introduced security enhancements for `record-add` commands, including escaping of backslashes and double quotes in titles and field values to prevent command injection. Added validation to reject control characters in field data. Updated CLI handlers to utilize a new argument-building function for improved safety and consistency. Added unit tests for new functionality and edge cases.